### PR TITLE
Port of MemoryStore from todoMVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /typings
 .baseDir.ts
 .tscache
+.tsconfig*.json
 coverage-unmapped.json
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ node_js:
 - '6'
 env:
   global:
-  # Please get your own free key if you want to test yourself
-  - BROWSERSTACK_USERNAME: << USERNAME GOES HERE >>
-  - BROWSERSTACK_ACCESS_KEY: << ACCESS KEY GOES HERE >>
-  - SAUCE_USERNAME: << USERNAME GOES HERE >>
-  - SAUCE_ACCESS_KEY: << ACCESS KEY GOES HERE >>
+  - SAUCE_USERNAME: dojo2-ts-ci
+  - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -7,21 +7,23 @@
 		"url": "https://github.com/dojo/stores/issues"
 	},
 	"license": "BSD-3-Clause",
+	"main": "main.js",
+	"private": true,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/dojo/stores.git"
 	},
 	"scripts": {
-		"prepublish": "grunt peerDepInstall dist",
+		"prepublish": "grunt peerDepInstall",
 		"test": "grunt test"
 	},
 	"peerDependencies": {
 		"@reactivex/rxjs": "5.0.0-beta.6",
 		"immutable": "^3.7.6",
-		"dojo-compose": ">=2.0.0-beta.9",
-		"dojo-core": ">=2.0.0-alpha.11",
-		"dojo-has": ">=2.0.0-alpha.3",
-		"dojo-shim": ">=2.0.0-alpha.3"
+		"dojo-compose": ">=2.0.0-beta.10",
+		"dojo-core": ">=2.0.0-alpha.12",
+		"dojo-has": ">=2.0.0-alpha.4",
+		"dojo-shim": ">=2.0.0-alpha.4"
 	},
 	"devDependencies": {
 		"codecov.io": "0.1.6",
@@ -32,7 +34,7 @@
 		"grunt-contrib-clean": "^1.0.0",
 		"grunt-contrib-copy": "^1.0.0",
 		"grunt-contrib-watch": "^1.0.0",
-		"grunt-dojo2": ">=2.0.0-beta.15",
+		"grunt-dojo2": ">=2.0.0-beta.16",
 		"grunt-text-replace": "^0.4.0",
 		"grunt-ts": "^5.5.1",
 		"grunt-tslint": "^3.2.1",
@@ -40,7 +42,7 @@
 		"intern": "^3.3.1",
 		"istanbul": "^0.4.5",
 		"remap-istanbul": "^0.6.4",
-		"tslint": "^3.15.1",
-		"typescript": "rc"
+		"tslint": "next",
+		"typescript": "2.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -11,19 +11,13 @@
 		"type": "git",
 		"url": "https://github.com/dojo/stores.git"
 	},
-	"files": [
-		"index.js",
-		"dist",
-		"src",
-		"typings.json"
-	],
 	"scripts": {
 		"prepublish": "grunt peerDepInstall dist",
 		"test": "grunt test"
 	},
-	"typings": "./typings/dist/umd/dojo-stores.d.ts",
 	"peerDependencies": {
 		"@reactivex/rxjs": "5.0.0-beta.6",
+		"immutable": "^3.7.6",
 		"dojo-compose": ">=2.0.0-beta.9",
 		"dojo-core": ">=2.0.0-alpha.11",
 		"dojo-has": ">=2.0.0-alpha.3",

--- a/src/createMemoryStore.ts
+++ b/src/createMemoryStore.ts
@@ -1,0 +1,405 @@
+import { OrderedMap, Map } from 'immutable/immutable';
+import { Observable } from 'rxjs/Observable';
+import { Observer } from 'rxjs/Observer';
+import { assign } from 'dojo-core/lang';
+import Promise, { isThenable } from 'dojo-shim/Promise';
+import WeakMap from 'dojo-shim/WeakMap';
+import compose, { ComposeFactory } from 'dojo-compose/compose';
+import createDestroyable, { Destroyable } from 'dojo-compose/mixins/createDestroyable';
+
+export type StoreIndex = number | string;
+
+export interface MemoryStorePragma {
+	/**
+	 * The identity of the object
+	 */
+	id?: StoreIndex;
+
+	/**
+	 * Should the item be replaced if already exists.
+	 */
+	replace?: boolean;
+}
+
+export interface MemoryStorePromise<T> extends Promise<T> {
+	/**
+	 * Retrieve an object from the store based on the object's ID
+	 * @param id The ID of the object to retrieve
+	 */
+	get(id: StoreIndex): MemoryStorePromise<T>;
+
+	get(): MemoryStorePromise<T>;
+
+	/**
+	 * Put an item in the object store.
+	 * @param item The item to put
+	 * @param options The pragma to use when putting the object
+	 */
+	put(item: T, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Add an item to the object store.
+	 * @param add The item to add
+	 * @param options The pragma to use when adding the object
+	 */
+	add(item: T, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Patch an object in the store by providing a partial object.  The result will be a promise
+	 * that resolves with the patched object.
+	 * @param partial The partial object to patch the existing object with
+	 * @param options The pragma to use when patching the object
+	 */
+	patch(partial: any, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Remove an object from the store.
+	 * @param id The ID of the object to remove
+	 * @param item The object to remove
+	 */
+	delete(id: StoreIndex): MemoryStorePromise<boolean>;
+	delete(item: T): MemoryStorePromise<boolean>;
+
+	/**
+	 * Set the stores objects to an array
+	 */
+	fromArray(items: T[]): MemoryStorePromise<void>;
+}
+
+export interface MemoryStoreOptions<T extends Object> {
+	/**
+	 * Any initial data that should populate the store
+	 */
+	data?: T[];
+
+	/**
+	 * The property of each object to use as the identity for the object
+	 */
+	idProperty?: StoreIndex;
+}
+
+export const enum ChangeTypes {
+	Add = 1,
+	Put,
+	Patch,
+	Delete
+}
+
+export interface ChangeRecord<T extends Object> {
+	type: ChangeTypes;
+	id: StoreIndex;
+	target?: T;
+}
+
+export interface MemoryStoreMixin<T extends Object> {
+	/**
+	 * The property that determines the ID of the object (defaults to `id`)
+	 */
+	idProperty: StoreIndex;
+
+	/**
+	 * Retrieve an object from the store based on the object's ID
+	 * @param id The ID of the object to retrieve
+	 */
+	get(id: StoreIndex): MemoryStorePromise<T>;
+	get(): MemoryStorePromise<T>;
+
+	/**
+	 * Observe an object, any subsequent changes to the object can also be observed via the observable
+	 * interface that is returned.  If the object is not present in the store, the observation will be
+	 * immediatly completed.  If the object is deleted from the store, the observation will be completed
+	 * @param id The ID of the object to observe
+	 */
+	observe(id: StoreIndex): Observable<T>;
+	observe(): Observable<ChangeRecord<T>>;
+
+	/**
+	 * Put an item in the object store.
+	 * @param item The item to put
+	 * @param options The pragma to use when putting the object
+	 */
+	put(item: T, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Add an item to the object store.
+	 * @param add The item to add
+	 * @param options The pragma to use when adding the object
+	 */
+	add(item: T, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Patch an object in the store by providing a partial object.  The result will be a promise
+	 * that resolves with the patched object.
+	 * @param partial The partial object to patch the existing object with
+	 * @param options The pragma to use when patching the object
+	 */
+	patch(partial: any, options?: MemoryStorePragma): MemoryStorePromise<T>;
+
+	/**
+	 * Remove an object from the store.
+	 * @param id The ID of the object to remove
+	 * @param item The object to remove
+	 */
+	delete(id: StoreIndex): MemoryStorePromise<boolean>;
+	delete(item: T): MemoryStorePromise<boolean>;
+
+	/**
+	 * Set the stores objects to an array
+	 */
+	fromArray(items: T[]): MemoryStorePromise<void>;
+}
+
+export type MemoryStore<T extends Object> = MemoryStoreMixin<T> & Destroyable;
+
+/**
+ * The weak map that contains the data for the stores
+ */
+const dataWeakMap = new WeakMap<MemoryStore<Object>, OrderedMap<StoreIndex, Object>>();
+
+/**
+ * The weak map that contains any observers for the stores
+ */
+const itemObserverWeakMap = new WeakMap<MemoryStore<Object>, Map<StoreIndex, Observer<Object>[]>>();
+
+/**
+ *
+ */
+const storeObserverWeakMap = new WeakMap<MemoryStore<Object>, Observer<Object>[]>();
+
+// const storeObserverWeakMap = new WeakMap<MemoryStore<Object>, Observer<ChangeRecord<Object>>[]>();
+
+export interface MemoryStoreFactory extends ComposeFactory<MemoryStore<Object>, MemoryStoreOptions<Object>> {
+	<T extends Object>(options?: MemoryStoreOptions<T>): MemoryStore<T>;
+
+	/**
+	 * Creates a memory store from an array of objects
+	 * @params data The array of data to create the memory store from
+	 */
+	fromArray<T extends Object>(data: T[]): MemoryStore<T>;
+}
+
+/**
+ * The methods to decorate the MemoryStorePromise with
+ */
+const storeMethods = [ 'get', 'put', 'add', 'patch', 'delete', 'fromArray' ];
+
+/**
+ * Utility function that takes a result and generates a MemoryStorePromise
+ * @param store The store to use as a reference when decorating the Promise
+ * @param result The result to wrap, if Thenable, it will be decorated, otherwise a new Promise is created
+ */
+function wrapResult<R>(store: MemoryStore<Object>, result: R): MemoryStorePromise<R> {
+	/* TODO: this all seems pretty expensive, there has to be a better way */
+	const p = (isThenable(result) ? result : Promise.resolve(result)) as MemoryStorePromise<R>;
+	storeMethods.forEach((method) => {
+		(<any> p)[method] = (...args: any[]) => {
+			return p.then(() => {
+				return (<any> store)[method].apply(store, args);
+			});
+		};
+	});
+	return p;
+}
+
+/**
+ * Utility function that takes an error and generates a rejected MemoryStorePromise
+ * @param store The store to use as a reference when decorating the Promise
+ * @param result The result to wrap
+ */
+function wrapError(store: MemoryStore<Object>, result: Error): MemoryStorePromise<Object> {
+	const p = (isThenable(result) ? result : Promise.reject(result)) as MemoryStorePromise<Object>;
+	storeMethods.forEach((method) => {
+		(<any> p)[method] = (...args: any[]) => {
+			return p.then(() => {
+				return (<any> store)[method].apply(store, args);
+			});
+		};
+	});
+	return p;
+}
+
+/**
+ * Create a new instance of a MemoryStore
+ */
+const createMemoryStore = compose<MemoryStoreMixin<Object>, MemoryStoreOptions<Object>>({
+		idProperty: 'id',
+
+		get(this: MemoryStore<Object>, id?: StoreIndex): MemoryStorePromise<Object | Iterator<Object>> {
+			const data = dataWeakMap.get(this);
+			if (id) {
+				return wrapResult(this, data && data.get(String(id)));
+			} else {
+				return wrapResult(this, data.values());
+			}
+		},
+
+		observe<T>(this: MemoryStore<Object>, id?: StoreIndex): Observable<T> {
+			const store = this;
+			if (id) {
+				return new Observable<T>(function subscribe(observer: Observer<T>) {
+					store.get(String(id)).then((item: T) => {
+						if (item) {
+							observer.next(item);
+							const observers = itemObserverWeakMap.get(store);
+							const observerArray: Observer<Object>[] = observers && observers.has(String(id)) ? observers.get(String(id)) : [];
+							observerArray.push(observer);
+							itemObserverWeakMap.set(store, (observers ? observers : Map<StoreIndex, Observer<Object>[]>()).set(String(id), observerArray));
+						}
+						else {
+							observer.error(new Error(`ID "${id}" not found in store`));
+						}
+					});
+				});
+			}
+			else {
+				return new Observable<T>(function subscribe(observer: Observer<T>) {
+					const data = dataWeakMap.get(store);
+					const observers = storeObserverWeakMap.get(store) || [];
+					const values: any = data.values();
+					const items = Array.from(values);
+					const payload: any = {
+						puts: items,
+						deletes: [],
+						beforeAll: [],
+						afterAll: items
+					};
+					observer.next(payload);
+					observers.push(observer);
+					storeObserverWeakMap.set(store, observers);
+				});
+			}
+		},
+
+		put(this: MemoryStore<Object>, item: { [property: string]: number | string | undefined; }, options?: MemoryStorePragma): MemoryStorePromise<Object> {
+			const store = this;
+			const data = dataWeakMap.get(store);
+			const beforeAll: any = data ? data.values() : [];
+			const idProperty: any = store.idProperty;
+			const id =  options && 'id' in options ? options.id :
+				idProperty in item ? item[idProperty] :
+				data ? data.size : 0;
+			if (options && options.replace === false && data && data.has(String(id))) {
+				return wrapError(store, Error(`Duplicate ID "${id}" when pragma "replace" is false`));
+			}
+			item[idProperty] = id;
+			dataWeakMap.set(store, (data ? data : OrderedMap<StoreIndex, Object>()).set(String(id), item));
+
+			const observers = itemObserverWeakMap.get(store);
+			if (observers && observers.has(String(id))) {
+				observers.get(String(id)).forEach((observer) => observer.next(item));
+			}
+			const storeObservers = storeObserverWeakMap.get(store);
+			if (storeObservers) {
+				const afterData = dataWeakMap.get(store);
+				const afterAll: any = afterData.values();
+				const payload: any = {
+					puts: [item],
+					deletes: [],
+					beforeAll: Array.from(beforeAll),
+					afterAll: Array.from(afterAll)
+				};
+				storeObservers.forEach((observer) => {
+					observer.next(payload);
+				});
+			}
+			return wrapResult(store, item);
+		},
+
+		add(this: MemoryStore<Object>, item: Object, options?: MemoryStorePragma): MemoryStorePromise<Object> {
+			return this.put(item, assign(options ? options : {}, { replace: false }));
+		},
+
+		patch(this: MemoryStore<Object>, partial: { [property: string]: number | string; }, options?: MemoryStorePragma): MemoryStorePromise<Object> {
+			const idProperty = this.idProperty;
+			const id = options && 'id' in options ? options.id : partial[idProperty];
+			if (!id) {
+				return wrapError(this, new Error(`Object ID must either be passed in "partial.${idProperty}" or "options.id"`));
+			}
+			return wrapResult(this, this.get(id).then((item: Object = {}) => {
+				options = options || {};
+				options.id = id;
+				return this.put(assign(item, partial), options);
+			}));
+		},
+
+		delete(this: MemoryStore<Object>, item: StoreIndex | { [property: string]: number | string; }): MemoryStorePromise<boolean> {
+			const store = this;
+			const idProperty = store.idProperty;
+			const data = dataWeakMap.get(store);
+			const beforeAll: any = data ? data.values() : [];
+
+			/**
+			 * Complete any observers associated with this items id
+			 */
+			function completeObservable(id: StoreIndex) {
+				const observers = itemObserverWeakMap.get(store);
+				if (observers && observers.has(String(id))) {
+					observers.get(String(id)).forEach((observer) => observer.complete());
+					itemObserverWeakMap.set(store, observers.delete(id));
+				}
+			}
+
+			function completeStoreObservers() {
+				const storeObservers = storeObserverWeakMap.get(store);
+				if (storeObservers) {
+					const afterData = dataWeakMap.get(store);
+					const afterAll: any = afterData.values();
+					const payload: any = {
+						puts: [],
+						deletes: [item],
+						beforeAll: Array.from(beforeAll),
+						afterAll: Array.from(afterAll)
+					};
+					storeObservers.forEach((observer) => {
+						observer.next(payload);
+					});
+				}
+			}
+			if (typeof item === 'object') {
+				if (idProperty in item && data && data.has(String(item[idProperty]))) {
+					dataWeakMap.set(store, data.delete(String(item[idProperty])));
+					completeObservable(item[idProperty]);
+					completeStoreObservers();
+					return wrapResult(store, true);
+				}
+			}
+			else {
+				if (data && data.has(String(item))) {
+					dataWeakMap.set(store, data.delete(String(item)));
+					completeObservable(item);
+					completeStoreObservers();
+					return wrapResult(store, true);
+				}
+			}
+			return wrapResult(store, false);
+		},
+		fromArray(this: MemoryStore<Object>, items: Object[]): MemoryStorePromise<void> {
+			const store: MemoryStore<Object> = this;
+			const map: Object = {};
+			const idProperty = store.idProperty;
+			items.forEach((item: { [prop: string]: StoreIndex }, idx: number) => {
+				const id = idProperty in item ? item[idProperty] : idx;
+				item[idProperty] = id;
+				(<any> map)[id] = item;
+			});
+			dataWeakMap.set(store, OrderedMap<StoreIndex, Object>(map));
+			return wrapResult(store, undefined);
+		}
+	}, (instance, options) => {
+		if (options) {
+			if (options.idProperty) {
+				instance.idProperty = options.idProperty;
+			}
+			if (options.data) {
+				instance.fromArray(options.data);
+			}
+		}
+	})
+	.mixin(createDestroyable)
+	.static({
+		fromArray(data: any[]): MemoryStore<any> {
+			return createMemoryStore({ data });
+		}
+	}) as MemoryStoreFactory;
+
+export default createMemoryStore;

--- a/src/createMemoryStore.ts
+++ b/src/createMemoryStore.ts
@@ -1,4 +1,4 @@
-import { OrderedMap, Map } from 'immutable/immutable';
+import { OrderedMap, Map } from 'immutable';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 import { assign } from 'dojo-core/lang';

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -53,7 +53,12 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' }
+		{ name: 'dojo-compose', location: 'node_modules/dojo-compose/dist/umd' },
+		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' },
+		{ name: 'dojo-has', location: 'node_modules/dojo-has/dist/umd' },
+		{ name: 'dojo-shim', location: 'node_modules/dojo-shim/dist/umd' },
+		{ name: 'immutable', location: 'node_modules/immutable/dist' },
+		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
 	]
 };
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -53,11 +53,11 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo-compose', location: 'node_modules/dojo-compose/dist/umd' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' },
-		{ name: 'dojo-has', location: 'node_modules/dojo-has/dist/umd' },
-		{ name: 'dojo-shim', location: 'node_modules/dojo-shim/dist/umd' },
-		{ name: 'immutable', location: 'node_modules/immutable/dist' },
+		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
+		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
+		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: 'immutable', location: 'node_modules/immutable/dist', main: 'immutable' },
 		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
 	]
 };

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,1 +1,2 @@
 import './main';
+import './createMemoryStore';

--- a/tests/unit/createMemoryStore.ts
+++ b/tests/unit/createMemoryStore.ts
@@ -1,0 +1,273 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import createMemoryStore from '../../src/createMemoryStore';
+
+registerSuite({
+	name: 'util/createMemoryStore',
+	'creation': {
+		'no options'() {
+			const store = createMemoryStore();
+			assert.strictEqual(store.idProperty, 'id');
+			assert.isFunction(store.add);
+			assert.isFunction(store.get);
+			assert.isFunction(store.put);
+			assert.isFunction(store.delete);
+			assert.isFunction(store.patch);
+			assert.isFunction(store.fromArray);
+		},
+		'options idProperty'() {
+			const store = createMemoryStore({
+				idProperty: 'foo'
+			});
+			assert.strictEqual(store.idProperty, 'foo');
+		},
+		'options data'() {
+			const store = createMemoryStore({
+				data: [
+					{ id: 1, foo: 'bar' },
+					{ id: 2, foo: 'baz' },
+					{ id: 3, foo: 'qat' },
+					{ id: 4, foo: 'qux' }
+				]
+			});
+			return store.get(3).then((item) => {
+				assert.deepEqual(item, { id: 3, foo: 'qat' });
+			});
+		}
+	},
+	'add()': {
+		'resolves to value'() {
+			const store = createMemoryStore();
+			return store.add({
+				id: 1,
+				foo: 'bar'
+			}).then((value) => {
+				assert.deepEqual(value, { id: 1, foo: 'bar' });
+			});
+		},
+		'can be chained'() {
+			const store = createMemoryStore();
+			return store
+				.add({ id: 1, foo: 'bar' })
+				.add({ id: 2, foo: 'baz' })
+				.then((result) => {
+					assert.deepEqual(result, { id: 2, foo: 'baz' });
+					return store.get(1).then((item) => {
+						assert.deepEqual(item, { id: 1, foo: 'bar' });
+					});
+				});
+		},
+		'add duplicate rejects'() {
+			const store = createMemoryStore();
+			return store
+				.add({ id: 1, foo: 'bar' })
+				.add({ id: 1, foo: 'baz' })
+				.then(() => {
+					throw new Error('Should have rejected');
+				}, (error: any) => {
+					assert.instanceOf(error, Error);
+					assert.include(error.message, 'Duplicate ID');
+				});
+		}
+	},
+	'fromArray()'() {
+		const store = createMemoryStore();
+		return store.fromArray([
+				{ id: 1, foo: 'bar' },
+				{ id: 2, foo: 'baz' },
+				{ id: 3, foo: 'qat' },
+				{ id: 4, foo: 'qux' }
+			])
+			.then(() => {
+				return store.get(2).then((item) => {
+					assert.deepEqual(item, { id: 2, foo: 'baz' });
+					return store.get(4).then((item) => {
+						assert.deepEqual(item, { id: 4, foo: 'qux' });
+					});
+				});
+			});
+	},
+	'static fromArray()'() {
+		const store = createMemoryStore.fromArray([
+			{ id: 1, foo: 'bar' },
+			{ id: 2, foo: 'baz' },
+			{ id: 3, foo: 'qat' },
+			{ id: 4, foo: 'qux' }
+		]);
+
+		return store.get(2).then((item) => {
+			assert.deepEqual(item, { id: 2, foo: 'baz' });
+			return store.get(4).then((item) => {
+				assert.deepEqual(item, { id: 4, foo: 'qux' });
+			});
+		});
+	},
+	'patch()': {
+		'partial'() {
+			const store = createMemoryStore({
+				data: [
+					{ id: 1, foo: 'bar' }
+				]
+			});
+
+			return store
+				.patch({ foo: 'qat', bar: 1 }, { id: 1 })
+				.then((item) => {
+					assert.deepEqual(item, { id: 1, foo: 'qat', bar: 1 });
+				});
+		},
+		'missing adds'() {
+			const store = createMemoryStore();
+
+			return store
+				.patch({ foo: 'qat', bar: 1 }, { id: 1 })
+				.then(() => {
+					return store.get(1);
+				})
+				.then((item) => {
+					assert.deepEqual(item, { foo: 'qat', bar: 1, id: 1 });
+				});
+		},
+		'missing id rejects'() {
+			const store = createMemoryStore();
+
+			return store
+				.patch({ foo: 'qat', bar: 1})
+				.then(() => {
+					throw new Error('Should have rejected');
+				}, (error: any) => {
+					assert.instanceOf(error, Error);
+					assert.strictEqual(error.message, 'Object ID must either be passed in "partial.id" or "options.id"');
+				});
+		}
+	},
+	'observer()': {
+		'subscribe'(this: any) {
+			const dfd = this.async();
+			const store = createMemoryStore<{ id: number; foo: string; }>();
+			store
+				.add({ id: 1, foo: 'bar' })
+				.then(() => {
+					const subscription: any = store.observe(1).subscribe(dfd.callback((item: { id: number; foo: string; }) => {
+						assert.deepEqual(item, { id: 1, foo: 'bar' });
+						subscription.unsubscribe();
+					}));
+				});
+		},
+		'receive updates'(this: any) {
+			const dfd = this.async();
+			const store = createMemoryStore({
+				data: [
+					{ id: 1, foo: 'bar' }
+				]
+			});
+
+			let count = 0;
+
+			const subscription: any = store.observe(1).subscribe((item) => {
+				count++;
+				if (count === 1) {
+					assert.deepEqual(item, { id: 1, foo: 'bar' });
+				}
+				else if (count === 2) {
+					assert.deepEqual(item, { id: 1, foo: 'baz' });
+					subscription.unsubscribe();
+					dfd.resolve();
+				}
+				else {
+					dfd.reject(new Error('Wrong number of calls: ' + count));
+				}
+			});
+
+			store.get(1).then((item: any) => {
+				item.foo = 'baz';
+				store.put(item);
+			});
+		},
+		'subscribe to missing id'(this: any) {
+			const dfd = this.async();
+			let callbackCount = 0;
+			let errorCount = 0;
+			let completeCount = 0;
+			const store = createMemoryStore();
+			store.observe(1).subscribe(() => {
+				callbackCount++;
+			}, () => {
+				errorCount++;
+			}, () => {
+				completeCount++;
+			});
+
+			setTimeout(dfd.callback(() => {
+				assert.strictEqual(callbackCount, 0);
+				assert.strictEqual(errorCount, 1);
+				assert.strictEqual(completeCount, 0);
+			}), 10);
+		}
+	},
+	'delete()': {
+		'by id'() {
+			const store = createMemoryStore({
+				data: [
+					{ id: 1, foo: 'bar' },
+					{ id: 2, foo: 'baz' },
+					{ id: 3, foo: 'qat' }
+				]
+			});
+
+			return store.delete(2)
+				.then((result) => {
+					assert.isTrue(result);
+					return store.get(2)
+						.then((result) => {
+							assert.isUndefined(result);
+						});
+				});
+		},
+		'by object'() {
+			const item = { id: 1, foo: 'bar' };
+			const store = createMemoryStore({
+				data: [ item ]
+			});
+
+			return store.delete(item)
+				.then((result) => {
+					assert.isTrue(result);
+				});
+		},
+		'not in store'() {
+			const store = createMemoryStore();
+
+			return store.delete('foo')
+				.then((result) => {
+					assert.isFalse(result);
+				});
+		},
+		'complete observable'(this: any) {
+			const dfd = this.async();
+			const stack: any[] = [];
+			let complete = false;
+			let errorCalled = false;
+			const store = createMemoryStore({
+				data: [ { id: 1, foo: 'foo' }]
+			});
+			store.observe(1).subscribe((item) => {
+				stack.push(item);
+			}, () => {
+				errorCalled = true;
+			}, () => {
+				complete = true;
+			});
+
+			setTimeout(() => {
+				store.delete(1);
+			}, 10);
+
+			setTimeout(dfd.callback(() => {
+				assert.strictEqual(stack.length, 1);
+				assert.isTrue(complete);
+				assert.isFalse(errorCalled);
+			}), 20);
+		}
+	}
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"compilerOptions": {
 		"baseUrl": "node_modules",
 		"declaration": false,
@@ -8,20 +8,6 @@
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"outDir": "_build/",
-		"paths": {
-			"dojo-has/*": [
-				"dojo-has/dist/umd/*"
-			],
-			"dojo-shim/*": [
-				"dojo-shim/dist/umd/*"
-			],
-			"dojo-core/*": [
-				"dojo-core/dist/umd/*"
-			],
-			"dojo-compose/*": [
-				"dojo-compose/dist/umd/*"
-			]
-		},
 		"removeComments": false,
 		"sourceMap": true,
 		"strictNullChecks": true,

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,6 @@
 {
 	"name": "dojo-stores",
 	"globalDependencies": {
-		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5"
 	},
 	"peerDependencies": {

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,11 @@
 {
 	"name": "dojo-stores",
 	"globalDependencies": {
+		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5"
 	},
 	"peerDependencies": {
+		"immutable": "npm:immutable",
 		"@reactivex/RxJS": "npm:@reactivex/rxjs"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Port [`createMemoryStore`](https://github.com/dojo/examples/blob/7416825/todo-mvc/src/utils/createLocalMemoryStore.ts) used in [**todoMVC**](https://github.com/dojo/examples/tree/master/todo-mvc) and replaces the version of [`createMemoryStore`](https://github.com/dojo/widgets/blob/92a0654/src/util/createMemoryStore.ts) used in [**dojo/widgets**](https://github.com/dojo/widgets).

resolves #8

Includes changes for https://github.com/dojo/meta/issues/68
