### PR TITLE
Increase capacity of observables stores before "RangeError: Maximum call stack size exceeded"

### DIFF
--- a/src/store/createQueryTransformResult.ts
+++ b/src/store/createQueryTransformResult.ts
@@ -665,7 +665,7 @@ export const createQueryTransformResult: QueryTransformResultFactory = compose<Q
 		// in an incorrect update
 		let nextUpdate: StoreDelta<any> = (state.queuedUpdates.length && mapped) ? mergeDeltas(
 			mapped,
-			...state.queuedUpdates.splice(0).map((update) => localizeUpdate(state, update, mapped, updateIndex))
+			state.queuedUpdates.splice(0).map((update) => localizeUpdate(state, update, mapped, updateIndex))
 		) : {
 			adds: [],
 			updates: [],

--- a/src/store/mixins/createObservableStoreMixin.ts
+++ b/src/store/mixins/createObservableStoreMixin.ts
@@ -51,7 +51,7 @@ export interface StoreDelta<T> {
  */
 export function mergeDeltas<T>(
 	instance: { identify(items: T | T[]): string[] },
-	...deltas: StoreDelta<T>[]
+	deltas: StoreDelta<T>[]
 ): StoreDelta<T> {
 	const head = deltas[0] || {
 			updates: [],
@@ -170,7 +170,7 @@ export function mergeDeltas<T>(
 	}
 
 	if (deltas[1]) {
-		const tail = mergeDeltas(instance, ...deltas.slice(1));
+		const tail = mergeDeltas(instance, deltas.slice(1));
 		const { oldDeletes, newAdds, newUpdates } = convertReplacementToUpdate(head.deletes, tail.adds, tail.updates);
 		const oldUpdates = removeOutdatedItems(tail.deletes, head.updates);
 		const { newDeletes, oldAdds } = removeCancellingUpdates(tail.deletes, head.adds);
@@ -357,7 +357,7 @@ function sendUpdates<T, O extends CrudOptions, U extends UpdateResults<T>>(
 	after?: T[]
 ) {
 	const state = instanceStateMap.get(store);
-	const storeDelta = mergeDeltas(store, ...state.queuedUpdates.splice(0));
+	const storeDelta = mergeDeltas(store, state.queuedUpdates.splice(0));
 	after = after || addUpdateDelete(store, state, state.localData, storeDelta);
 
 	storeDelta.beforeAll = state.localData;


### PR DESCRIPTION
**Type:** bug

**Description:** 

This improves the capacity of stores before causing the `RangeError: Maximum call stack size exceeded` error but it still fails when increasing the number of entries added to `5390` using the example in the issue.

All the tests still pass and I couldn't see an obvious reason for spreading the arrays.

**Related Issue:** #89

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
