### PR TITLE
Updating to importHelpers and downlevelIteration

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -14,7 +14,7 @@
 	],
 	"browser": {
 		"loader": {
-			"script": "./node_modules/grunt-dojo2/lib/intern/internloader.js",
+			"script": "./node_modules/grunt-dojo2/lib/intern/internLoader.js",
 			"options": {
 				"packages": [
 					{ "name": "src", "location": "_build/src" },

--- a/intern.json
+++ b/intern.json
@@ -1,5 +1,5 @@
 {
-	"capabilities": {
+	"capabilities+": {
 		"project": "Dojo 2",
 		"name": "@dojo/stores"
 	},
@@ -12,15 +12,15 @@
 	"functionalSuites": [
 		"./_build/tests/functional/all.js"
 	],
-	"loader": {
-		"script": "dojo2",
-		"options": {
-			"packages": [
-				{ "name": "src", "location": "_build/src" },
-				{ "name": "tests", "location": "_build/tests" },
-				{ "name": "@dojo", "location": "node_modules/@dojo" },
-				{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" }
-			]
+	"browser": {
+		"loader": {
+			"script": "./node_modules/grunt-dojo2/lib/intern/internloader.js",
+			"options": {
+				"packages": [
+					{ "name": "src", "location": "_build/src" },
+					{ "name": "tests", "location": "_build/tests" }
+				]
+			}
 		}
 	},
 	"coverage": [

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/core": "~0.1.0",
+    "@dojo/core": "~0.2.1",
     "@dojo/has": "~0.1.0",
-    "@dojo/shim": "~0.1.0"
+    "@dojo/shim": "~0.2.2"
   },
   "devDependencies": {
     "@dojo/interfaces": "~0.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"strictNullChecks": true,
+		"importHelpers": true,
+		"downlevelIteration": true,
 		"target": "es5",
 		"types": [ "intern" ]
 	},


### PR DESCRIPTION
Upgrading shim/core and using `downlevelIteration`, `importsHelpers`, and the new grunt-dojo2 intern loader.