### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -418,7 +418,17 @@ const myProcess = createProcess([ commandOne ], myCallbackDecorator());
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7921,27 +7921,60 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
-      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "diff": "3.4.0",
-        "findup-sync": "0.3.0",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "1.9.1"
+        "tsutils": "2.13.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "resolve": {
@@ -7951,6 +7984,24 @@
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.8.1"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -54,7 +54,7 @@
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -69,7 +69,7 @@
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
@@ -91,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -106,7 +106,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/diff": {
@@ -132,7 +132,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/fs-extra": {
@@ -141,7 +141,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/grunt": {
@@ -150,7 +150,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/handlebars": {
@@ -230,9 +230,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -260,9 +260,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz",
-      "integrity": "sha512-K8w0FWNsIRcw615d/Et90wMRvLfg8XH1T77fC0xObbusE3+eXwnitdoF9j0CS9zBt8A57J/TKgRVe7RX9ZlT1g==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
+      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
       "dev": true
     },
     "@types/platform": {
@@ -277,7 +277,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/serve-static": {
@@ -302,7 +302,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/sinon": {
@@ -329,13 +329,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abbrev": {
@@ -415,6 +415,21 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -425,6 +440,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "any-promise": {
@@ -442,6 +469,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -576,7 +609,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -640,14 +673,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -928,7 +961,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "electron-to-chromium": "1.3.28"
       }
     },
@@ -992,15 +1025,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1085,6 +1118,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1099,6 +1138,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1198,6 +1284,12 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
@@ -1336,6 +1428,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1571,6 +1702,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1674,6 +1811,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1833,6 +1976,12 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1906,6 +2055,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -1954,6 +2113,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2064,14 +2229,21 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2101,6 +2273,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2171,6 +2353,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2332,6 +2520,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2641,7 +2835,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.4",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2660,11 +2854,40 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -2797,9 +3020,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -2822,7 +3045,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3045,6 +3268,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3119,9 +3367,9 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
+      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
@@ -3131,7 +3379,7 @@
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3142,7 +3390,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3172,7 +3420,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3367,6 +3615,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3452,6 +3715,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3479,10 +3751,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3742,6 +4026,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -3872,6 +4217,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3891,11 +4242,247 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4080,6 +4667,62 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -4406,6 +5049,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4413,6 +5065,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4491,6 +5162,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4529,6 +5206,18 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -4622,6 +5311,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -5936,6 +6631,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6235,9 +6963,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -6378,6 +7106,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6395,6 +7129,16 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -6432,6 +7176,23 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -6629,6 +7390,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6702,6 +7469,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6715,6 +7488,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6767,6 +7549,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6855,6 +7648,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -7116,15 +7915,15 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7133,9 +7932,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7143,7 +7943,26 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -8366,7 +9185,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "peerDependencies": {
@@ -29,8 +31,28 @@
     "glob": "^7.0.6",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
+    "prettier": "1.9.2",
     "sinon": "^1.17.6",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-staged": "6.0.0",
     "prettier": "1.9.2",
     "sinon": "^1.17.6",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -141,7 +141,7 @@ export class Store<T = any> extends Evented implements State<T> {
 	public onChange = <U = any>(paths: Path<T, U> | Path<T, U>[], callback: () => void) => {
 		const callbackId = this._callbackId;
 		if (!Array.isArray(paths)) {
-			paths = [ paths ];
+			paths = [paths];
 		}
 		paths.forEach((path) => this._addOnChange(path, callback, callbackId));
 		this._callbackId += 1;
@@ -157,7 +157,7 @@ export class Store<T = any> extends Evented implements State<T> {
 				});
 			}
 		};
-	}
+	};
 
 	private _addOnChange = <U = any>(path: Path<T, U>, callback: () => void, callbackId: number): void => {
 		let changePaths = this._changePaths.get(path.path);
@@ -166,7 +166,7 @@ export class Store<T = any> extends Evented implements State<T> {
 		}
 		changePaths.callbacks.push({ callbackId, callback });
 		this._changePaths.set(path.path, changePaths);
-	}
+	};
 
 	private _runOnChanges() {
 		const callbackIdsCalled: number[] = [];

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -23,19 +23,19 @@ export interface State<M> {
 	get<S>(path: Path<M, S>): S;
 	path<T, P0 extends keyof T>(path: Path<M, T>, a: P0): Path<M, T[P0]>;
 	path<T, P0 extends keyof T, P1 extends keyof T[P0]>(path: Path<M, T>, a: P0, b: P1): Path<M, T[P0][P1]>;
-	path<
-		T,
-		P0 extends keyof T,
-		P1 extends keyof T[P0],
-		P2 extends keyof T[P0][P1]
-		>(path: Path<M, T>, a: P0, b: P1, c: P2): Path<M, T[P0][P1][P2]>;
-	path<
-		T,
-		P0 extends keyof T,
-		P1 extends keyof T[P0],
-		P2 extends keyof T[P0][P1],
-		P3 extends keyof T[P0][P1][P2]
-		>(path: Path<M, T>, a: P0, b: P1, c: P2, d: P3): Path<M, T[P0][P1][P2][P3]>;
+	path<T, P0 extends keyof T, P1 extends keyof T[P0], P2 extends keyof T[P0][P1]>(
+		path: Path<M, T>,
+		a: P0,
+		b: P1,
+		c: P2
+	): Path<M, T[P0][P1][P2]>;
+	path<T, P0 extends keyof T, P1 extends keyof T[P0], P2 extends keyof T[P0][P1], P3 extends keyof T[P0][P1][P2]>(
+		path: Path<M, T>,
+		a: P0,
+		b: P1,
+		c: P2,
+		d: P3
+	): Path<M, T[P0][P1][P2][P3]>;
 	path<
 		T,
 		P0 extends keyof T,
@@ -43,23 +43,40 @@ export interface State<M> {
 		P2 extends keyof T[P0][P1],
 		P3 extends keyof T[P0][P1][P2],
 		P4 extends keyof T[P0][P1][P2][P3]
-		>(path: Path<M, T>, a: P0, b: P1, c: P2, d: P3, e: P4): Path<M, T[P0][P1][P2][P3][P4]>;
+	>(
+		path: Path<M, T>,
+		a: P0,
+		b: P1,
+		c: P2,
+		d: P3,
+		e: P4
+	): Path<M, T[P0][P1][P2][P3][P4]>;
 	path<P0 extends keyof M>(a: P0): Path<M, M[P0]>;
 	path<P0 extends keyof M, P1 extends keyof M[P0]>(a: P0, b: P1): Path<M, M[P0][P1]>;
-	path<P0 extends keyof M, P1 extends keyof M[P0], P2 extends keyof M[P0][P1]>(a: P0, b: P1, c: P2): Path<M, M[P0][P1][P2]>;
-	path<
-		P0 extends keyof M,
-		P1 extends keyof M[P0],
-		P2 extends keyof M[P0][P1],
-		P3 extends keyof M[P0][P1][P2]
-	>(a: P0, b: P1, c: P2, d: P3): Path<M, M[P0][P1][P2][P3]>;
+	path<P0 extends keyof M, P1 extends keyof M[P0], P2 extends keyof M[P0][P1]>(
+		a: P0,
+		b: P1,
+		c: P2
+	): Path<M, M[P0][P1][P2]>;
+	path<P0 extends keyof M, P1 extends keyof M[P0], P2 extends keyof M[P0][P1], P3 extends keyof M[P0][P1][P2]>(
+		a: P0,
+		b: P1,
+		c: P2,
+		d: P3
+	): Path<M, M[P0][P1][P2][P3]>;
 	path<
 		P0 extends keyof M,
 		P1 extends keyof M[P0],
 		P2 extends keyof M[P0][P1],
 		P3 extends keyof M[P0][P1][P2],
 		P4 extends keyof M[P0][P1][P2][P3]
-	>(a: P0, b: P1, c: P2, d: P3, e: P4): Path<M, M[P0][P1][P2][P3][P4]>;
+	>(
+		a: P0,
+		b: P1,
+		c: P2,
+		d: P3,
+		e: P4
+	): Path<M, M[P0][P1][P2][P3][P4]>;
 	at<S extends Path<M, Array<any>>>(path: S, index: number): Path<M, S['value'][0]>;
 }
 
@@ -81,7 +98,6 @@ function isString(segment?: string): segment is string {
  * Application state store
  */
 export class Store<T = any> extends Evented implements State<T> {
-
 	/**
 	 * The private state object
 	 */
@@ -96,7 +112,7 @@ export class Store<T = any> extends Evented implements State<T> {
 	 */
 	public get = <U = any>(path: Path<T, U>): U => {
 		return path.value;
-	}
+	};
 
 	/**
 	 * Applies store operations to state and returns the undo operations
@@ -109,7 +125,7 @@ export class Store<T = any> extends Evented implements State<T> {
 			this.invalidate();
 		}
 		return patchResult.undoOperations;
-	}
+	};
 
 	public at = <U = any>(path: Path<T, Array<U>>, index: number): Path<T, U> => {
 		const array = this.get(path);
@@ -120,7 +136,7 @@ export class Store<T = any> extends Evented implements State<T> {
 			state: path.state,
 			value
 		};
-	}
+	};
 
 	public onChange = <U = any>(paths: Path<T, U> | Path<T, U>[], callback: () => void) => {
 		const callbackId = this._callbackId;
@@ -178,24 +194,23 @@ export class Store<T = any> extends Evented implements State<T> {
 		this.emit({ type: 'invalidate' });
 	}
 
-	public path: State<T>['path']  = (path: string | Path<T, any>, ...segments: (string | undefined)[]) => {
+	public path: State<T>['path'] = (path: string | Path<T, any>, ...segments: (string | undefined)[]) => {
 		if (typeof path === 'string') {
-			segments = [ path, ...segments ];
-		}
-		else {
-			segments = [ ...new Pointer(path.path).segments, ...segments ];
+			segments = [path, ...segments];
+		} else {
+			segments = [...new Pointer(path.path).segments, ...segments];
 		}
 
 		const stringSegments = segments.filter<string>(isString);
 		const hasMultipleSegments = stringSegments.length > 1;
-		const pointer = new Pointer(hasMultipleSegments ? stringSegments : (stringSegments[0] || ''));
+		const pointer = new Pointer(hasMultipleSegments ? stringSegments : stringSegments[0] || '');
 
 		return {
 			path: pointer.path,
 			state: this._state,
 			value: pointer.get(this._state)
 		};
-	}
+	};
 }
 
 export default Store;

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,10 +1,4 @@
-import {
-	ProcessError,
-	ProcessResult,
-	ProcessCallback,
-	ProcessCallbackDecorator,
-	Undo
-} from './process';
+import { ProcessError, ProcessResult, ProcessCallback, ProcessCallbackDecorator, Undo } from './process';
 
 /**
  * Undo manager interface

--- a/src/state/Patch.ts
+++ b/src/state/Patch.ts
@@ -31,7 +31,11 @@ export interface TestPatchOperation<T = any, U = any> extends BaseOperation<T, U
 	value: U;
 }
 
-export type PatchOperation<T = any, U = any> = AddPatchOperation<T, U> | RemovePatchOperation<T, U> | ReplacePatchOperation<T, U> | TestPatchOperation<T, U>;
+export type PatchOperation<T = any, U = any> =
+	| AddPatchOperation<T, U>
+	| RemovePatchOperation<T, U>
+	| ReplacePatchOperation<T, U>
+	| TestPatchOperation<T, U>;
 
 export interface PatchResult<T = any, U = any> {
 	object: T;
@@ -41,8 +45,7 @@ export interface PatchResult<T = any, U = any> {
 function add(pointerTarget: PointerTarget, value: any): any {
 	if (Array.isArray(pointerTarget.target)) {
 		pointerTarget.target.splice(parseInt(pointerTarget.segment, 10), 0, value);
-	}
-	else {
+	} else {
 		pointerTarget.target[pointerTarget.segment] = value;
 	}
 	return pointerTarget.object;
@@ -51,8 +54,7 @@ function add(pointerTarget: PointerTarget, value: any): any {
 function replace(pointerTarget: PointerTarget, value: any): any {
 	if (Array.isArray(pointerTarget.target)) {
 		pointerTarget.target.splice(parseInt(pointerTarget.segment, 10), 1, value);
-	}
-	else {
+	} else {
 		pointerTarget.target[pointerTarget.segment] = value;
 	}
 	return pointerTarget.object;
@@ -61,8 +63,7 @@ function replace(pointerTarget: PointerTarget, value: any): any {
 function remove(pointerTarget: PointerTarget): any {
 	if (Array.isArray(pointerTarget.target)) {
 		pointerTarget.target.splice(parseInt(pointerTarget.segment, 10), 1);
-	}
-	else {
+	} else {
 		delete pointerTarget.target[pointerTarget.segment];
 	}
 	return pointerTarget.object;
@@ -79,13 +80,11 @@ export function isObject(value: any): value is Object {
 export function isEqual(a: any, b: any): boolean {
 	if (Array.isArray(a) && Array.isArray(b)) {
 		return a.length === b.length && a.every((element: any, i: number) => isEqual(element, b[i]));
-	}
-	else if (isObject(a) && isObject(b)) {
+	} else if (isObject(a) && isObject(b)) {
 		const keysForA = Object.keys(a).sort();
 		const keysForB = Object.keys(b).sort();
-		return isEqual(keysForA, keysForB) && keysForA.every(key => isEqual(a[key], b[key]));
-	}
-	else {
+		return isEqual(keysForA, keysForB) && keysForA.every((key) => isEqual(a[key], b[key]));
+	} else {
 		return a === b;
 	}
 }
@@ -101,9 +100,8 @@ function inverse(operation: PatchOperation, state: any): any[] {
 			path: operation.path,
 			value: operation.value
 		};
-		return [ test, op ];
-	}
-	else if (operation.op === OperationType.REPLACE) {
+		return [test, op];
+	} else if (operation.op === OperationType.REPLACE) {
 		const op = {
 			op: OperationType.REPLACE,
 			path: operation.path,
@@ -114,14 +112,15 @@ function inverse(operation: PatchOperation, state: any): any[] {
 			path: operation.path,
 			value: operation.value
 		};
-		return [ test, op ];
-	}
-	else  {
-		return [{
-			op: OperationType.ADD,
-			path: operation.path,
-			value: operation.path.get(state)
-		}];
+		return [test, op];
+	} else {
+		return [
+			{
+				op: OperationType.ADD,
+				path: operation.path,
+				value: operation.path.get(state)
+			}
+		];
 	}
 }
 
@@ -129,7 +128,7 @@ export class Patch<T = any> {
 	private _operations: PatchOperation<T>[];
 
 	constructor(operations: PatchOperation<T> | PatchOperation<T>[]) {
-		this._operations = Array.isArray(operations) ? operations : [ operations ];
+		this._operations = Array.isArray(operations) ? operations : [operations];
 	}
 
 	public apply(object: any): PatchResult<T> {
@@ -156,7 +155,7 @@ export class Patch<T = any> {
 				default:
 					throw new Error('Unknown operation');
 			}
-			undoOperations = [ ...undoOperations, ...inverse(next, patchedObject) ];
+			undoOperations = [...undoOperations, ...inverse(next, patchedObject)];
 			return object;
 		}, object);
 		return { object: patchedObject, undoOperations };

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -32,25 +32,20 @@ export function walk(segments: string[], object: any, clone = true): PointerTarg
 
 			if (clone || target === undefined) {
 				if (Array.isArray(target)) {
-					target = [ ...target ];
-				}
-				else if (typeof target === 'object') {
+					target = [...target];
+				} else if (typeof target === 'object') {
 					target = { ...target };
-				}
-				else if (isNaN(parseInt(nextSegment, 0))) {
+				} else if (isNaN(parseInt(nextSegment, 0))) {
 					target = {};
-				}
-				else {
+				} else {
 					target = [];
 				}
 				pointerTarget.target[segment] = target;
 				pointerTarget.target = target;
-			}
-			else {
+			} else {
 				pointerTarget.target = target;
 			}
-		}
-		else {
+		} else {
 			pointerTarget.segment = segment;
 		}
 		return pointerTarget;
@@ -63,12 +58,11 @@ export class Pointer<T = any, U = any> {
 	constructor(segments: string | string[]) {
 		if (Array.isArray(segments)) {
 			this._segments = segments;
-		}
-		else {
-			this._segments = (segments[0] === '/' ? segments : `/${segments}`).split('/') ;
+		} else {
+			this._segments = (segments[0] === '/' ? segments : `/${segments}`).split('/');
 			this._segments.shift();
 		}
-		if (segments.length === 0 || (segments.length === 1 && (segments[0] === '/') || segments[0] === '')) {
+		if (segments.length === 0 || ((segments.length === 1 && segments[0] === '/') || segments[0] === '')) {
 			throw new Error('Access to the root is not supported.');
 		}
 		this._segments = this._segments.map(decode);

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -1,8 +1,14 @@
-import { RemovePatchOperation, ReplacePatchOperation, AddPatchOperation, TestPatchOperation, OperationType } from './Patch';
+import {
+	RemovePatchOperation,
+	ReplacePatchOperation,
+	AddPatchOperation,
+	TestPatchOperation,
+	OperationType
+} from './Patch';
 import { Pointer } from './Pointer';
 import { Path } from '../Store';
 
-export function add<T = any, U = any>(path: Path<T,  U>, value: U): AddPatchOperation<T, U> {
+export function add<T = any, U = any>(path: Path<T, U>, value: U): AddPatchOperation<T, U> {
 	return {
 		op: OperationType.ADD,
 		path: new Pointer(path.path),

--- a/tests/unit/Store.ts
+++ b/tests/unit/Store.ts
@@ -7,11 +7,9 @@ import { Pointer } from './../../src/state/Pointer';
 
 let store: Store = new Store();
 
-const testPatchOperations: PatchOperation[] = [
-	{ op: OperationType.ADD, path: new Pointer('/test'), value: 'test'}
-];
+const testPatchOperations: PatchOperation[] = [{ op: OperationType.ADD, path: new Pointer('/test'), value: 'test' }];
 
-describe('store',  () => {
+describe('store', () => {
 	beforeEach(() => {
 		store = new Store();
 	});
@@ -102,13 +100,13 @@ describe('store',  () => {
 	});
 
 	describe('paths', () => {
-		let store: Store<{ foo: { bar: string }, baz: number[] }>;
+		let store: Store<{ foo: { bar: string }; baz: number[] }>;
 
 		beforeEach(() => {
-			store = new Store<{ foo: { bar: string }, baz: number[] }>();
+			store = new Store<{ foo: { bar: string }; baz: number[] }>();
 			store.apply([
 				{ op: OperationType.ADD, path: new Pointer('/foo'), value: { bar: 'bar' } },
-				{ op: OperationType.ADD, path: new Pointer('/baz'), value: [ 5 ] }
+				{ op: OperationType.ADD, path: new Pointer('/baz'), value: [5] }
 			]);
 		});
 
@@ -129,9 +127,13 @@ describe('store',  () => {
 		});
 
 		it('should not return the root', () => {
-			assert.throws(() => {
-				store.get(store.path('' as any));
-			}, Error, 'Access to the root is not supported.');
+			assert.throws(
+				() => {
+					store.get(store.path('' as any));
+				},
+				Error,
+				'Access to the root is not supported.'
+			);
 		});
 	});
 });

--- a/tests/unit/Store.ts
+++ b/tests/unit/Store.ts
@@ -34,25 +34,28 @@ describe('store', () => {
 
 		const { onChange, path, apply } = store;
 
-		onChange(path('foo', 'bar'), () => first += 1);
+		onChange(path('foo', 'bar'), () => (first += 1));
 
-		onChange([
-			path('foo', 'bar'),
-			path('baz')
-		], () => second += 1);
+		onChange([path('foo', 'bar'), path('baz')], () => (second += 1));
 
-		apply([
-			{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
-			{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello' }
-		], true);
+		apply(
+			[
+				{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
+				{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello' }
+			],
+			true
+		);
 
 		assert.strictEqual(first, 1);
 		assert.strictEqual(second, 1);
 
-		apply([
-			{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
-			{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'world' }
-		], true);
+		apply(
+			[
+				{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
+				{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'world' }
+			],
+			true
+		);
 
 		assert.strictEqual(first, 1);
 		assert.strictEqual(second, 2);
@@ -64,27 +67,30 @@ describe('store', () => {
 
 		const { onChange, path, apply } = store;
 
-		const { remove } = onChange(path('foo', 'bar'), () => first += 1);
+		const { remove } = onChange(path('foo', 'bar'), () => (first += 1));
 
-		onChange([
-			path('foo', 'bar'),
-			path('baz')
-		], () => second += 1);
+		onChange([path('foo', 'bar'), path('baz')], () => (second += 1));
 
-		apply([
-			{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
-			{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello' }
-		], true);
+		apply(
+			[
+				{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test' },
+				{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello' }
+			],
+			true
+		);
 
 		assert.strictEqual(first, 1);
 		assert.strictEqual(second, 1);
 
 		remove();
 
-		apply([
-			{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test2' },
-			{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello2' }
-		], true);
+		apply(
+			[
+				{ op: OperationType.ADD, path: new Pointer('/foo/bar'), value: 'test2' },
+				{ op: OperationType.ADD, path: new Pointer('/baz'), value: 'hello2' }
+			],
+			true
+		);
 
 		assert.strictEqual(first, 1);
 		assert.strictEqual(second, 2);

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -9,20 +9,20 @@ import { Store } from './../../src/Store';
 
 function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): PatchOperation[] {
 	let counter = get(path('counter')) || 0;
-	return [
-		{ op: OperationType.REPLACE, path: new Pointer('/counter'), value: ++counter }
-	];
-};
+	return [{ op: OperationType.REPLACE, path: new Pointer('/counter'), value: ++counter }];
+}
 
 describe('extras', () => {
-
 	it('collects undo functions for all processes using collector', () => {
 		const { undoCollector, undoer } = createUndoManager();
 		const store = new Store();
 		let localUndoStack: any[] = [];
-		const incrementCounterProcess = createProcess([ incrementCounter ], undoCollector((error, result) => {
-			localUndoStack.push(result.undo);
-		}));
+		const incrementCounterProcess = createProcess(
+			[incrementCounter],
+			undoCollector((error, result) => {
+				localUndoStack.push(result.undo);
+			})
+		);
 		const executor = incrementCounterProcess(store);
 		executor();
 		assert.strictEqual(store.get(store.path('counter')), 1);
@@ -39,7 +39,7 @@ describe('extras', () => {
 	it('undo has no effect if there are no undo functions on the stack', () => {
 		const { undoer } = createUndoManager();
 		const store = new Store();
-		const incrementCounterProcess = createProcess([ incrementCounter ]);
+		const incrementCounterProcess = createProcess([incrementCounter]);
 		const executor = incrementCounterProcess(store);
 		executor();
 		undoer();
@@ -50,15 +50,22 @@ describe('extras', () => {
 		const { undoCollector, undoer } = createUndoManager();
 		const store = new Store();
 		let localUndo: any;
-		const incrementCounterProcess = createProcess([ incrementCounter ], undoCollector((error, result) => {
-			localUndo = result.undo;
-		}));
+		const incrementCounterProcess = createProcess(
+			[incrementCounter],
+			undoCollector((error, result) => {
+				localUndo = result.undo;
+			})
+		);
 		const executor = incrementCounterProcess(store);
 		executor();
 		assert.strictEqual(store.get(store.path('counter')), 1);
 		undoer();
-		assert.throws(() => {
-			localUndo && localUndo();
-		}, Error, 'Test operation failure. Unable to apply any operations.');
+		assert.throws(
+			() => {
+				localUndo && localUndo();
+			},
+			Error,
+			'Test operation failure. Unable to apply any operations.'
+		);
 	});
 });

--- a/tests/unit/state/Patch.ts
+++ b/tests/unit/state/Patch.ts
@@ -6,9 +6,7 @@ import { Patch, OperationType } from './../../../src/state/Patch';
 import * as ops from './../../../src/state/operations';
 
 describe('state/Patch', () => {
-
 	describe('add', () => {
-
 		it('value to new path', () => {
 			const patch = new Patch(ops.add({ path: 'test', state: null, value: null }, 'test'));
 			const obj = {};
@@ -16,8 +14,8 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: 'test' });
 			assert.deepEqual(result.undoOperations, [
-				{op: 'test', path: new Pointer('/test'), value: 'test'},
-				{op: 'remove', path: new Pointer('/test') }
+				{ op: 'test', path: new Pointer('/test'), value: 'test' },
+				{ op: 'remove', path: new Pointer('/test') }
 			]);
 		});
 
@@ -28,8 +26,8 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { foo: { bar: { qux: 'test' } } });
 			assert.deepEqual(result.undoOperations, [
-				{op: 'test', path: new Pointer('/foo/bar/qux'), value: 'test'},
-				{op: 'remove', path: new Pointer('/foo/bar/qux') }
+				{ op: 'test', path: new Pointer('/foo/bar/qux'), value: 'test' },
+				{ op: 'remove', path: new Pointer('/foo/bar/qux') }
 			]);
 		});
 
@@ -40,8 +38,8 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: 'test' });
 			assert.deepEqual(result.undoOperations, [
-				{op: 'test', path: new Pointer('/test'), value: 'test'},
-				{op: 'remove', path: new Pointer('/test') }
+				{ op: 'test', path: new Pointer('/test'), value: 'test' },
+				{ op: 'remove', path: new Pointer('/test') }
 			]);
 		});
 
@@ -52,15 +50,13 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: ['test'] });
 			assert.deepEqual(result.undoOperations, [
-				{op: 'test', path: new Pointer('/test/0'), value: 'test'},
-				{op: 'remove', path: new Pointer('/test/0') }
+				{ op: 'test', path: new Pointer('/test/0'), value: 'test' },
+				{ op: 'remove', path: new Pointer('/test/0') }
 			]);
 		});
-
 	});
 
 	describe('replace', () => {
-
 		it('new path', () => {
 			const patch = new Patch(ops.replace({ path: '/test', state: null, value: null }, 'test'));
 			const obj = {};
@@ -68,8 +64,8 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: 'test' });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.TEST, path: new Pointer('/test'), value: 'test'},
-				{op: OperationType.REPLACE, path: new Pointer('/test'), value: undefined }
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/test'), value: undefined }
 			]);
 		});
 
@@ -80,8 +76,8 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { foo: { bar: { qux: 'test' } } });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.TEST, path: new Pointer('/foo/bar/qux'), value: 'test'},
-				{op: OperationType.REPLACE, path: new Pointer('/foo/bar/qux'), value: undefined }
+				{ op: OperationType.TEST, path: new Pointer('/foo/bar/qux'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/foo/bar/qux'), value: undefined }
 			]);
 		});
 
@@ -92,64 +88,60 @@ describe('state/Patch', () => {
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { test: 'test' });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.TEST, path: new Pointer('/test'), value: 'test'},
-				{op: OperationType.REPLACE, path: new Pointer('/test'), value: true }
+				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/test'), value: true }
 			]);
 		});
 
 		it('array index path', () => {
 			const patch = new Patch(ops.replace({ path: '/test/1', state: null, value: null }, 'test'));
-			const obj = { test: [ 'test', 'foo' ] };
+			const obj = { test: ['test', 'foo'] };
 			const result = patch.apply(obj);
 			assert.notStrictEqual(result.object, obj);
-			assert.deepEqual(result.object, { test: [ 'test', 'test' ] });
+			assert.deepEqual(result.object, { test: ['test', 'test'] });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.TEST, path: new Pointer('/test/1'), value: 'test'},
-				{op: OperationType.REPLACE, path: new Pointer('/test/1'), value: 'foo' }
+				{ op: OperationType.TEST, path: new Pointer('/test/1'), value: 'test' },
+				{ op: OperationType.REPLACE, path: new Pointer('/test/1'), value: 'foo' }
 			]);
 		});
-
 	});
 
 	describe('remove', () => {
-
 		it('new path', () => {
-			const patch = new Patch(ops.remove({ path:  '/test', state: null, value: null }));
+			const patch = new Patch(ops.remove({ path: '/test', state: null, value: null }));
 			const obj = { other: true };
 			const result = patch.apply(obj);
 			assert.notStrictEqual(result.object, obj);
 			assert.deepEqual(result.object, { other: true });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.ADD, path: new Pointer('/test'), value: undefined }
+				{ op: OperationType.ADD, path: new Pointer('/test'), value: undefined }
 			]);
 		});
 
 		it('existing path', () => {
-			const patch = new Patch(ops.remove({ path:  '/test', state: null, value: null }));
+			const patch = new Patch(ops.remove({ path: '/test', state: null, value: null }));
 			const obj = { test: true };
 			const result = patch.apply(obj);
 			assert.notStrictEqual(result.object, obj);
-			assert.deepEqual(result.object, { });
+			assert.deepEqual(result.object, {});
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.ADD, path: new Pointer('/test'), value: true }
+				{ op: OperationType.ADD, path: new Pointer('/test'), value: true }
 			]);
 		});
 
 		it('array index path', () => {
 			const patch = new Patch(ops.remove({ path: '/test/1', state: null, value: null }));
-			const obj = { test: [ 'test', 'foo' ] };
+			const obj = { test: ['test', 'foo'] };
 			const result = patch.apply(obj);
 			assert.notStrictEqual(result.object, obj);
-			assert.deepEqual(result.object, { test: [ 'test' ] });
+			assert.deepEqual(result.object, { test: ['test'] });
 			assert.deepEqual(result.undoOperations, [
-				{op: OperationType.ADD, path: new Pointer('/test/1'), value: 'foo' }
+				{ op: OperationType.ADD, path: new Pointer('/test/1'), value: 'foo' }
 			]);
 		});
-
 	});
 
 	describe('test', () => {
-
 		it('success', () => {
 			const patch = new Patch(ops.test({ path: '/test', state: null, value: null }, 'test'));
 			const obj = { test: 'test' };
@@ -160,42 +152,60 @@ describe('state/Patch', () => {
 		it('failure', () => {
 			const patch = new Patch(ops.test({ path: '/test', state: null, value: null }, true));
 			const obj = { test: 'test' };
-			assert.throws(() => {
-				patch.apply(obj);
-			}, Error, 'Test operation failure. Unable to apply any operations.');
+			assert.throws(
+				() => {
+					patch.apply(obj);
+				},
+				Error,
+				'Test operation failure. Unable to apply any operations.'
+			);
 		});
 
 		it('nested path', () => {
 			const patch = new Patch(ops.test({ path: '/foo/0/bar/baz/0/qux', state: null, value: null }, true));
 			const obj = {
-				foo: [ {
-					bar: {
-						baz: [{
-							qux: true
-						}]
+				foo: [
+					{
+						bar: {
+							baz: [
+								{
+									qux: true
+								}
+							]
+						}
 					}
-				}]
+				]
 			};
 			const result = patch.apply(obj);
 			assert.strictEqual(result.object, obj);
 		});
 
 		it('complex value', () => {
-			const patch = new Patch(ops.test({ path: '/foo', state: null, value: null }, [ {
-				bar: {
-					baz: [{
-						qux: true
-					}]
-				}
-			}]));
-			const obj = {
-				foo: [ {
-					bar: {
-						baz: [{
-							qux: true
-						}]
+			const patch = new Patch(
+				ops.test({ path: '/foo', state: null, value: null }, [
+					{
+						bar: {
+							baz: [
+								{
+									qux: true
+								}
+							]
+						}
 					}
-				}]
+				])
+			);
+			const obj = {
+				foo: [
+					{
+						bar: {
+							baz: [
+								{
+									qux: true
+								}
+							]
+						}
+					}
+				]
 			};
 			const result = patch.apply(obj);
 			assert.strictEqual(result.object, obj);
@@ -214,9 +224,12 @@ describe('state/Patch', () => {
 			op: 'unknown',
 			path: new Pointer('/test')
 		} as any);
-		assert.throws(() => {
-			patch.apply({});
-		}, Error, 'Unknown operation');
+		assert.throws(
+			() => {
+				patch.apply({});
+			},
+			Error,
+			'Unknown operation'
+		);
 	});
-
 });

--- a/tests/unit/state/Pointer.ts
+++ b/tests/unit/state/Pointer.ts
@@ -4,55 +4,70 @@ const { assert } = intern.getPlugin('chai');
 import { Pointer, walk } from './../../../src/state/Pointer';
 
 describe('state/Pointer', () => {
-
 	it('create pointer with string path', () => {
 		const pointer = new Pointer('/foo/bar');
 		assert.strictEqual(pointer.path, '/foo/bar');
-		assert.deepEqual(pointer.segments, [ 'foo', 'bar' ]);
+		assert.deepEqual(pointer.segments, ['foo', 'bar']);
 	});
 
 	it('create pointer with array path', () => {
-		const pointer = new Pointer([ 'foo', 'bar' ]);
+		const pointer = new Pointer(['foo', 'bar']);
 		assert.strictEqual(pointer.path, '/foo/bar');
-		assert.deepEqual(pointer.segments, [ 'foo', 'bar' ]);
+		assert.deepEqual(pointer.segments, ['foo', 'bar']);
 	});
 
 	it('create with special characters', () => {
 		const pointer = new Pointer('/foo/bar~0~1');
 		assert.strictEqual(pointer.path, '/foo/bar~0~1');
-		assert.deepEqual(pointer.segments, [ 'foo', 'bar~/' ]);
+		assert.deepEqual(pointer.segments, ['foo', 'bar~/']);
 	});
 
 	it('create pointer for root should error', () => {
-		assert.throws(() => {
-			new Pointer('');
-		}, Error, 'Access to the root is not supported.');
-		assert.throws(() => {
-			new Pointer(['']);
-		}, Error, 'Access to the root is not supported.');
-		assert.throws(() => {
-			new Pointer('/');
-		}, Error, 'Access to the root is not supported.');
-		assert.throws(() => {
-			new Pointer(['/']);
-		}, Error, 'Access to the root is not supported.');
+		assert.throws(
+			() => {
+				new Pointer('');
+			},
+			Error,
+			'Access to the root is not supported.'
+		);
+		assert.throws(
+			() => {
+				new Pointer(['']);
+			},
+			Error,
+			'Access to the root is not supported.'
+		);
+		assert.throws(
+			() => {
+				new Pointer('/');
+			},
+			Error,
+			'Access to the root is not supported.'
+		);
+		assert.throws(
+			() => {
+				new Pointer(['/']);
+			},
+			Error,
+			'Access to the root is not supported.'
+		);
 	});
 
 	it('get', () => {
 		const pointer = new Pointer('/foo/bar/3');
-		const obj = { foo: { bar: [ 1, 2, 3, 4, 5, 6, 7 ] } };
+		const obj = { foo: { bar: [1, 2, 3, 4, 5, 6, 7] } };
 		assert.strictEqual(pointer.get(obj), 4);
 	});
 
 	it('get last item in array', () => {
 		const pointer = new Pointer('/foo/bar/-');
-		const obj = { foo: { bar: [ 1, 2, 3, 4, 5, 6, 7 ] } };
+		const obj = { foo: { bar: [1, 2, 3, 4, 5, 6, 7] } };
 		assert.strictEqual(pointer.get(obj), 7);
 	});
 
 	it('get deep path that does not exist', () => {
 		const pointer = new Pointer('/foo/bar/qux');
-		const obj = { };
+		const obj = {};
 		assert.strictEqual(pointer.get(obj), undefined);
 	});
 

--- a/tests/unit/state/operations.ts
+++ b/tests/unit/state/operations.ts
@@ -6,7 +6,6 @@ import { OperationType } from './../../../src/state/Patch';
 import { Pointer } from './../../../src/state/Pointer';
 
 describe('state/operations', () => {
-
 	it('add()', () => {
 		const result = operations.add({ path: '/test', state: null, value: null }, 'test');
 		assert.deepEqual(result, {
@@ -17,7 +16,7 @@ describe('state/operations', () => {
 	});
 
 	it('remove()', () => {
-		const result = operations.remove({ path:  '/test', state: null, value: null });
+		const result = operations.remove({ path: '/test', state: null, value: null });
 		assert.deepEqual(result, {
 			op: OperationType.REMOVE,
 			path: new Pointer('/test')
@@ -41,5 +40,4 @@ describe('state/operations', () => {
 			value: 'test'
 		});
 	});
-
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -35,9 +37,7 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -57,7 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
