### PR TITLE
Support typing for command and executor `payload`,  defaulted to `object`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ function addTodoCommand({ at, path, get, payload }: CommandRequest) {
 	const todosPath = path('todos');
 	const length = get(todosPath).length;
 	const operations = [
-		add(at(todosPath, length), payload[0])
+		add(at(todosPath, length), payload)
 	];
 
 	return operations;
@@ -142,7 +142,7 @@ const addTodoCommand = createCommand(({ at, get, path, payload }) => {
 	const operations = [
 		// Using the utilities provided by the `operations` module ensures that the paths provided are valid,
 		// and that the values being added or replaced are of the appropriate type
-		add(at(path('todos'), todos.length), payload[0])
+		add(at(path('todos'), todos.length), payload)
 	];
 
 	return operations;
@@ -166,7 +166,7 @@ const calculateCountsCommand = createCommand(({ get, path }) => {
 Commands support asynchronous behavior out of the box simply by returning a `Promise<PatchOperation[]>`.
 
 ```ts
-async function postTodoCommand({ get, path, payload: [ id ] }: CommandRequest): Promise<PatchOperation[]> {
+async function postTodoCommand({ get, path, payload: { id }}: CommandRequest): Promise<PatchOperation[]> {
 	const response = await fetch('/todos');
 	if (!response.ok) {
 		throw new Error('Unable to post todo');
@@ -337,8 +337,8 @@ The `undo` function will rollback all the operations that were performed by the 
 An optional `transformer` can be passed to the `createExecutor` function that will be used to parse the arguments passed to the executor.
 
 ```ts
-function transformer(...payload: any[]): any {
-	return { id: uuid(), value: payload[0] };
+function transformer(payload: object): object {
+	return { id: uuid(), value: payload };
 }
 
 const executor = process(state, transformer);
@@ -391,7 +391,7 @@ function byId(id: string) {
 	return (item: any) => id === item.id;
 }
 
-async function deleteTodoCommand({ get, payload: [ id ] }: CommandRequest) {
+async function deleteTodoCommand({ get, payload: { id } }: CommandRequest) {
     const { todo, index } = find(get('/todos'), byId(id))
     await fetch(`/todo/${todo.id}`, { method: 'DELETE' } );
     return [ remove(`/todos/${index}`) ];

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ function calculateCountsCommand({ get, path }: CommandRequest) {
 }
 ```
 
-A `Command`, or the `CommandRequest` argument to it, can be provided with a generics that indicates the type of the state of the store they are intended to target and the payload that will be passed. This will provide type checking for all calls to `path` and `at` and usages of `payload`, ensuring that the operations will be targeting real properties of the store, and providing type inference for the return type of `get`.
+A `Command`, or the `CommandRequest` argument to it, can be provided with generics that indicate the type of the state of the store they are intended to target and the payload that will be passed. This will provide type checking for all calls to `path` and `at` and usages of `payload`, ensuring that the operations will be targeting real properties of the store, and providing type inference for the return type of `get`.
 
 ```ts
 interface MyState {
@@ -279,6 +279,13 @@ executorTwo({ foo: 'foo' }); // compile error, as requires both `bar` and `foo`
 executorTwo({ foo: 'foo', bar: 'bar' }); // Yay, valid
 ```
 
+Alternatively the payload can be typed at command creation
+
+```ts
+const createCommandOne = createCommandFactory<MyState>();
+const commandOne = createCommandOne<{ foo: string }>(({ get, path, payload }) => []);
+```
+
 ## How does this differ from Redux
 
 Although Dojo 2 stores is a big atom state store, you never get access to the entire state object. To access the sections of state that are needed we use pointers to return the slice of state that is needed i.e. `path('path', 'to', 'state')`. State is never directly updated by the user, with state changes only being processed by the operations returned by commands.
@@ -334,7 +341,7 @@ The `undo` function will rollback all the operations that were performed by the 
 
 ### Transforming Executor Arguments
 
-An optional `transformer` can be passed to a process that is be used to transform the `executor`s payload to the `command` payload type. The return type of the `transformer` must match the `command` `payload` type of the `process`. The argument type of the `executor` is inferred from transformers `payload` type.
+An optional `transformer` can be passed to a process that is used to transform the `executor`s payload to the `command` payload type. The return type of the `transformer` must match the `command` `payload` type of the `process`. The argument type of the `executor` is inferred from transformers `payload` type.
 
 ```ts
 interface CommandPayload {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/stores",
-  "version": "0.3.0-pre",
+  "version": "0.3.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/process.ts
+++ b/src/process.ts
@@ -3,9 +3,16 @@ import { PatchOperation } from './state/Patch';
 import { State, Store } from './Store';
 
 /**
+ * Default Payload interface
+ */
+export interface DefaultPayload {
+	[index: string]: any;
+}
+
+/**
  * The arguments passed to a `Command`
  */
-export interface CommandRequest<T = any, P extends object = object> extends State<T> {
+export interface CommandRequest<T = any, P extends object = DefaultPayload> extends State<T> {
 	payload: P;
 }
 
@@ -13,29 +20,29 @@ export interface CommandRequest<T = any, P extends object = object> extends Stat
  * A command factory interface. Returns the passed command. This provides a way to automatically infer and/or
  * verify the type of multiple commands without explicitly specifying the generic for each command
  */
-export interface CommandFactory<T = any, P extends object = object> {
+export interface CommandFactory<T = any, P extends object = DefaultPayload> {
 	<R extends object = P>(command: Command<T, R>): Command<T, R>;
 }
 
 /**
  * Command that returns patch operations based on the command request
  */
-export interface Command<T = any, P extends object = object> {
+export interface Command<T = any, P extends object = DefaultPayload> {
 	(request: CommandRequest<T, P>): Promise<PatchOperation<T>[]> | PatchOperation<T>[];
 }
 
 /**
  * Transformer function
  */
-export interface Transformer<P extends object = object, R = any> {
+export interface Transformer<P extends object = DefaultPayload, R extends object = DefaultPayload> {
 	(payload: R): P;
 }
 
 /**
  * A process that returns an executor using a Store and Transformer
  */
-export interface Process<T = any, P extends object = object> {
-	<R>(store: Store<T>, transformer: Transformer<P, R>): ProcessExecutor<T, P, R>;
+export interface Process<T = any, P extends object = DefaultPayload> {
+	<R extends object = DefaultPayload>(store: Store<T>, transformer: Transformer<P, R>): ProcessExecutor<T, P, R>;
 	(store: Store<T>): ProcessExecutor<T, P, P>;
 }
 
@@ -48,7 +55,7 @@ export interface ProcessError<T = any> {
 }
 
 export interface ProcessResultExecutor<T = any> {
-	<P extends object = object, R extends object = object>(
+	<P extends object = DefaultPayload, R extends object = DefaultPayload>(
 		process: Process<T, P>,
 		payload: R,
 		transformer: Transformer<P, R>
@@ -59,7 +66,7 @@ export interface ProcessResultExecutor<T = any> {
 /**
  * Represents a successful result from a ProcessExecutor
  */
-export interface ProcessResult<T = any, P extends object = object> extends State<T> {
+export interface ProcessResult<T = any, P extends object = DefaultPayload> extends State<T> {
 	executor: ProcessResultExecutor<T>;
 	undo: Undo;
 	operations: PatchOperation<T>[];
@@ -71,7 +78,7 @@ export interface ProcessResult<T = any, P extends object = object> extends State
 /**
  * Runs a process for the given arguments.
  */
-export interface ProcessExecutor<T = any, P extends object = object, R = any> {
+export interface ProcessExecutor<T = any, P extends object = DefaultPayload, R extends object = DefaultPayload> {
 	(payload: R): Promise<ProcessResult<T, P>>;
 }
 
@@ -99,21 +106,21 @@ export interface ProcessCallbackDecorator {
 /**
  * CreateProcess factory interface
  */
-export interface CreateProcess<T = any, P extends object = object> {
+export interface CreateProcess<T = any, P extends object = DefaultPayload> {
 	(commands: (Command<T, P>[] | Command<T, P>)[], callback?: ProcessCallback<T>): Process<T, P>;
 }
 
 /**
  * Creates a command factory with the specified type
  */
-export function createCommandFactory<T, P extends object = object>(): CommandFactory<T, P> {
+export function createCommandFactory<T, P extends object = DefaultPayload>(): CommandFactory<T, P> {
 	return <R extends object = P>(command: Command<T, R>) => command;
 }
 
 /**
  * Commands that can be passed to a process
  */
-export type Commands<T = any, P extends object = object> = (Command<T, P>[] | Command<T, P>)[];
+export type Commands<T = any, P extends object = DefaultPayload> = (Command<T, P>[] | Command<T, P>)[];
 
 export interface ProcessOptions {
 	callback?: ProcessCallback;
@@ -125,7 +132,7 @@ export interface ProcessOptions {
  * @param commands The commands for the process
  * @param callback Callback called after the process is completed
  */
-export function createProcess<T = any, P extends object = object>(
+export function createProcess<T = any, P extends object = DefaultPayload>(
 	commands: Commands<T, P>,
 	{ callback }: ProcessOptions = {}
 ): Process<T, P> {

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -24,11 +24,11 @@ describe('extras', () => {
 			})
 		);
 		const executor = incrementCounterProcess(store);
-		executor();
+		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);
-		executor();
+		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 2);
-		executor();
+		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 3);
 		localUndoStack[2]();
 		assert.strictEqual(store.get(store.path('counter')), 2);
@@ -41,7 +41,7 @@ describe('extras', () => {
 		const store = new Store();
 		const incrementCounterProcess = createProcess([incrementCounter]);
 		const executor = incrementCounterProcess(store);
-		executor();
+		executor({});
 		undoer();
 		assert.strictEqual(store.get(store.path('counter')), 1);
 	});
@@ -57,7 +57,7 @@ describe('extras', () => {
 			})
 		);
 		const executor = incrementCounterProcess(store);
-		executor();
+		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);
 		undoer();
 		assert.throws(

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -17,12 +17,11 @@ describe('extras', () => {
 		const { undoCollector, undoer } = createUndoManager();
 		const store = new Store();
 		let localUndoStack: any[] = [];
-		const incrementCounterProcess = createProcess(
-			[incrementCounter],
-			undoCollector((error, result) => {
+		const incrementCounterProcess = createProcess([incrementCounter], {
+			callback: undoCollector((error, result) => {
 				localUndoStack.push(result.undo);
 			})
-		);
+		});
 		const executor = incrementCounterProcess(store);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);
@@ -50,12 +49,11 @@ describe('extras', () => {
 		const { undoCollector, undoer } = createUndoManager();
 		const store = new Store();
 		let localUndo: any;
-		const incrementCounterProcess = createProcess(
-			[incrementCounter],
-			undoCollector((error, result) => {
+		const incrementCounterProcess = createProcess([incrementCounter], {
+			callback: undoCollector((error, result) => {
 				localUndo = result.undo;
 			})
-		);
+		});
 		const executor = incrementCounterProcess(store);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -157,7 +157,7 @@ describe('process', () => {
 		const createCommand = createCommandFactory<{ foo: string }, { foo: string }>();
 
 		const command = createCommand(({ get, path, payload }) => {
-			// get(path('bar')); shouldn't compile
+			// get(path('bar')); // shouldn't compile
 			payload.foo;
 			// payload.bar; // shouldn't compile
 			get(path('foo'));
@@ -219,6 +219,10 @@ describe('process', () => {
 		// processTwo(store)({ foo: 3 }); // compile error
 		processOneResult.then((result) => {
 			result.payload.bar.toPrecision();
+			result.executor(processTwo, { foo: 3, bar: 1 });
+			// result.executor(processTwo, { foo: 3, bar: '' }); // compile error
+			result.executor(processTwo, { foo: 1 }, transformerTwo);
+			// result.executor(processTwo, { foo: '' }, transformerTwo); // compile error
 			// result.payload.bar.toUpperCase(); // compile error
 			// result.payload.foo; // compile error
 		});

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -163,21 +163,29 @@ describe('process', () => {
 
 	it('can type payload that extends an object', () => {
 		const createCommandOne = createCommandFactory<any, { foo: string }>();
-		const createCommandTwo = createCommandFactory();
+		const createCommandTwo = createCommandFactory<any, { bar: string }>();
+		const createCommandThree = createCommandFactory();
 		const commandOne = createCommandOne(({ get, path, payload }) => []);
 		const commandTwo = createCommandTwo(({ get, path, payload }) => []);
-		const processOne = createProcess([commandOne]);
+		const commandThree = createCommandThree(({ get, path, payload }) => []);
+		const processOne = createProcess<any, { foo: string; bar: string }>([commandOne, commandTwo]);
+		// createProcess([commandOne, commandTwo]); // shouldn't compile
 		// createProcess<any, { bar: string }>([commandOne]); // shouldn't compile
 		const processTwo = createProcess([commandTwo]);
+		const processThree = createProcess([commandThree]);
 		const executorOne = processOne(store);
 		const executorTwo = processTwo(store);
+		const executorThree = processThree(store);
 
 		// executorOne({}); // shouldn't compile
-		executorOne({ foo: 'bar' });
-		executorTwo({ foo: 'bar' });
-		executorTwo({});
+		// executorOne({ foo: 1 }); // shouldn't compile
+		executorOne({ foo: 'bar', bar: 'string' });
+		executorTwo({ bar: 'bar' });
+		// executorTwo({}); // shouldn't compile;
 		// executorTwo(1); // shouldn't compile
 		// executorTwo(''); // shouldn't compile
+		// executorThree(); // shouldn't compile
+		executorThree({});
 	});
 
 	it('can provide a callback that gets called on process completion', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Switches the `payload` from rest params (`...payload: any[]`) type to a single mandatory type that extends `object`. 

The type of payload can be defined by a second generic for both `commands` and `createProcess`.

```ts
const createCommandOne = createCommandFactory<any, { foo: string }>();
const createCommandTwo = createCommandFactory();
const commandOne = createCommandOne(({ get, path, payload }) => []);
const commandTwo = createCommandTwo(({ get, path, payload }) => []);
const processOne = createProcess([commandOne]);

createProcess<any, { bar: string }>([commandOne]); // compilation error
const processTwo = createProcess([commandTwo]);
const executorOne = processOne(store);
const executorTwo = processTwo(store);

executorOne({}); // compilation error
executorOne({ foo: 'bar' });
executorTwo({ foo: 'bar' });
executorTwo({});
executorTwo(1); // compilation error
executorTwo(''); // compilation error
executorTwo(); // compilation error
```

Resolves #146 

  