### PR TITLE
History Manager

### DIFF
--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,4 +1,4 @@
-import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallbackDecorator } from './process';
+import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallback } from './process';
 import { Pointer } from '../src/state/Pointer';
 import Store from '../src/Store';
 import WeakMap from '@dojo/shim/WeakMap';
@@ -8,110 +8,106 @@ export interface HistoryData {
 	redo: { id: string; operations: any[] }[];
 }
 
-export interface HistoryManager {
-	collector: ProcessCallbackDecorator;
-	serialize: (store: Store) => HistoryData;
-	deserialize: (store: Store, data: HistoryData) => void;
-	undo: (store: Store) => void;
-	redo: (store: Store) => void;
-	canUndo: (store: Store) => boolean;
-	canRedo: (store: Store) => boolean;
+export class HistoryManager {
+	private _storeMap = new WeakMap();
+
+	public collector(callback?: ProcessCallback): ProcessCallback {
+		return (error: ProcessError | null, result: ProcessResult): void => {
+			const { operations, undoOperations, id, store } = result;
+			const { history, undo } = this._storeMap.get(store) || {
+				history: [],
+				undo: []
+			};
+			history.push({ id, operations });
+			undo.push({ id, operations: undoOperations });
+			this._storeMap.set(store, { history, undo, redo: [] });
+			callback && callback(error, result);
+		};
+	}
+
+	public canUndo(store: Store): boolean {
+		const stacks = this._storeMap.get(store);
+		if (stacks) {
+			const { history, undo } = stacks;
+			if (undo.length && history.length) {
+				return true;
+			}
+		}
+		return false;
+	}
+	public canRedo(store: Store): boolean {
+		const stacks = this._storeMap.get(store);
+		if (stacks) {
+			const { redo } = stacks;
+			if (redo.length) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public redo(store: Store) {
+		const stacks = this._storeMap.get(store);
+		if (stacks) {
+			const { history, redo, undo } = stacks;
+			if (redo.length) {
+				const { id, operations } = redo.pop();
+				const result = store.apply(operations);
+				history.push({ id, operations });
+				undo.push({ id, operations: result });
+				this._storeMap.set(store, { history, undo, redo });
+			}
+		}
+	}
+
+	public undo(store: Store) {
+		const stacks = this._storeMap.get(store);
+		if (stacks) {
+			const { history, undo, redo } = stacks;
+			if (undo.length && history.length) {
+				const { id, operations } = undo.pop();
+				history.pop();
+				const result = store.apply(operations);
+				redo.push({ id, operations: result });
+				this._storeMap.set(store, { history, undo, redo });
+			}
+		}
+	}
+
+	public deserialize(store: Store, data: HistoryData) {
+		const { history, redo } = data;
+		history.forEach(({ id, operations }: any) => {
+			operations = (operations as any[]).map((operation) => {
+				operation.path = new Pointer(operation.path);
+				return operation;
+			});
+			let callback;
+			const process = getProcess(id);
+			if (process) {
+				callback = process[2];
+			}
+			processExecutor(id, [() => operations], store, callback, undefined)({});
+		});
+		const stacks = this._storeMap.get(store);
+		redo.forEach(({ id, operations }: any) => {
+			operations = (operations as any[]).map((operation) => {
+				operation.path = new Pointer(operation.path);
+				return operation;
+			});
+		});
+		stacks.redo = redo;
+	}
+
+	public serialize(store: Store): HistoryData {
+		const stacks = this._storeMap.get(store);
+		if (stacks) {
+			return {
+				history: stacks.history,
+				redo: stacks.redo
+			};
+		}
+		return { history: [], redo: [] };
+	}
 }
 
-export function createHistoryManager(): HistoryManager {
-	const storeMap = new WeakMap();
-	return {
-		collector(callback?) {
-			return (error: ProcessError | null, result: ProcessResult): void => {
-				const { operations, undoOperations, id, store } = result;
-				const { history, undo } = storeMap.get(store) || {
-					history: [],
-					undo: []
-				};
-				history.push({ id, operations });
-				undo.push({ id, operations: undoOperations });
-				storeMap.set(store, { history, undo, redo: [] });
-				callback && callback(error, result);
-			};
-		},
-		canUndo(store) {
-			const stacks = storeMap.get(store);
-			if (stacks) {
-				const { history, undo } = stacks;
-				if (undo.length && history.length) {
-					return true;
-				}
-			}
-			return false;
-		},
-		canRedo(store) {
-			const stacks = storeMap.get(store);
-			if (stacks) {
-				const { redo } = stacks;
-				if (redo.length) {
-					return true;
-				}
-			}
-			return false;
-		},
-		redo(store) {
-			const stacks = storeMap.get(store);
-			if (stacks) {
-				const { history, redo, undo } = stacks;
-				if (redo.length) {
-					const { id, operations } = redo.pop();
-					const result = store.apply(operations);
-					history.push({ id, operations });
-					undo.push({ id, operations: result });
-					storeMap.set(store, { history, undo, redo });
-				}
-			}
-		},
-		undo(store) {
-			const stacks = storeMap.get(store);
-			if (stacks) {
-				const { history, undo, redo } = stacks;
-				if (undo.length && history.length) {
-					const { id, operations } = undo.pop();
-					history.pop();
-					const result = store.apply(operations);
-					redo.push({ id, operations: result });
-					storeMap.set(store, { history, undo, redo });
-				}
-			}
-		},
-		deserialize(store, data) {
-			const { history, redo } = data;
-			history.forEach(({ id, operations }: any) => {
-				operations = (operations as any[]).map((operation) => {
-					operation.path = new Pointer(operation.path);
-					return operation;
-				});
-				let callback;
-				const process = getProcess(id);
-				if (process) {
-					callback = process[2];
-				}
-				processExecutor(id, [() => operations], store, callback, undefined)({});
-			});
-			const stacks = storeMap.get(store);
-			redo.forEach(({ id, operations }: any) => {
-				operations = (operations as any[]).map((operation) => {
-					operation.path = new Pointer(operation.path);
-					return operation;
-				});
-			});
-			stacks.redo = redo;
-		},
-		serialize(store) {
-			const stacks = storeMap.get(store);
-			if (stacks) {
-				return {
-					history: stacks.history,
-					redo: stacks.redo
-				};
-			}
-			return { history: [], redo: [] };
-		}
-	};
-}
+export default HistoryManager;

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,5 +1,5 @@
 import {
-	createProcess,
+	processExecutor,
 	getProcess,
 	ProcessError,
 	ProcessResult,
@@ -85,7 +85,7 @@ export function createHistoryManager(): HistoryManager {
 						callback = options.callback;
 					}
 				}
-				return createProcess(processId, [() => operations], callback)(store)({});
+				processExecutor(processId, [() => operations], store, callback, undefined)({});
 			});
 		},
 		serialize(store) {

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,21 +1,22 @@
 import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallbackDecorator } from './process';
 import { Pointer } from '../src/state/Pointer';
+import Store from '../src/Store';
 import WeakMap from '@dojo/shim/WeakMap';
 
 export interface HistoryManager {
 	collector: ProcessCallbackDecorator;
-	serialize: (store: any) => any;
-	deserialize: (store: any, data: any) => void;
-	undo: (store: any) => void;
-	redo: (store: any) => void;
-	canUndo: (store: any) => boolean;
-	canRedo: (store: any) => boolean;
+	serialize: (store: Store) => any;
+	deserialize: (store: Store, data: any) => void;
+	undo: (store: Store) => void;
+	redo: (store: Store) => void;
+	canUndo: (store: Store) => boolean;
+	canRedo: (store: Store) => boolean;
 }
 
 export function createHistoryManager(): HistoryManager {
 	const storeMap = new WeakMap();
 	return {
-		collector(callback?: any) {
+		collector(callback?) {
 			return (error: ProcessError | null, result: ProcessResult): void => {
 				const { operations, undoOperations, id, store } = result;
 				const { history, undo } = storeMap.get(store) || {

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -15,12 +15,12 @@ export function createHistoryManager(): HistoryManager {
 	return {
 		collector(callback?: any) {
 			return (error: ProcessError | null, result: ProcessResult): void => {
-				const { operations, undoOperations, processId, store } = result;
+				const { operations, undoOperations, id, store } = result;
 				const { history, undo } = storeMap.get(store) || {
 					history: [],
 					undo: []
 				};
-				history.push({ processId, operations });
+				history.push({ id, operations });
 				undo.push(undoOperations);
 				storeMap.set(store, { history, undo });
 				callback && callback(error, result);
@@ -38,19 +38,17 @@ export function createHistoryManager(): HistoryManager {
 			}
 		},
 		deserialize(store, history) {
-			history.forEach(({ processId, operations }: any) => {
+			history.forEach(({ id, operations }: any) => {
 				operations = (operations as any[]).map((operation) => {
 					operation.path = new Pointer(operation.path);
 					return operation;
 				});
 				let callback;
-				if (processId) {
-					const process = getProcess(processId);
-					if (process) {
-						callback = process[2];
-					}
+				const process = getProcess(id);
+				if (process) {
+					callback = process[2];
 				}
-				processExecutor(processId, [() => operations], store, callback, undefined)({});
+				processExecutor(id, [() => operations], store, callback, undefined)({});
 			});
 		},
 		serialize(store) {

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -3,10 +3,15 @@ import { Pointer } from '../src/state/Pointer';
 import Store from '../src/Store';
 import WeakMap from '@dojo/shim/WeakMap';
 
+export interface HistoryData {
+	history: { id: string; operations: any[] }[];
+	redo: { id: string; operations: any[] }[];
+}
+
 export interface HistoryManager {
 	collector: ProcessCallbackDecorator;
-	serialize: (store: Store) => any;
-	deserialize: (store: Store, data: any) => void;
+	serialize: (store: Store) => HistoryData;
+	deserialize: (store: Store, data: HistoryData) => void;
 	undo: (store: Store) => void;
 	redo: (store: Store) => void;
 	canUndo: (store: Store) => boolean;

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -85,7 +85,7 @@ export class HistoryManager {
 		const { history, redo } = data;
 		history.forEach(({ id, operations }: HistoryOperation) => {
 			operations = operations.map((operation) => {
-				operation.path = new Pointer(operation.path);
+				operation.path = new Pointer(String(operation.path));
 				return operation;
 			});
 			let callback;
@@ -98,7 +98,7 @@ export class HistoryManager {
 		const stacks = this._storeMap.get(store);
 		redo.forEach(({ id, operations }: HistoryOperation) => {
 			operations = operations.map((operation) => {
-				operation.path = new Pointer(operation.path);
+				operation.path = new Pointer(String(operation.path));
 				return operation;
 			});
 		});

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -14,8 +14,8 @@ import WeakMap from '@dojo/shim/WeakMap';
  * Undo manager interface
  */
 export interface UndoManager {
-	undoCollector: ProcessCallbackDecorator;
-	undoer: (store: any) => void;
+	collector: ProcessCallbackDecorator;
+	undo: (store: any) => void;
 }
 
 /**
@@ -26,7 +26,7 @@ export function createUndoManager(): UndoManager {
 	const storeMap = new WeakMap();
 
 	return {
-		undoCollector: (callback?: any): ProcessCallback => {
+		collector: (callback?: any): ProcessCallback => {
 			return (error: ProcessError | null, result: ProcessResult): void => {
 				const { undo, store } = result;
 				const undoStack = storeMap.get(store) || [];
@@ -43,7 +43,7 @@ export function createUndoManager(): UndoManager {
 				callback && callback(error, result);
 			};
 		},
-		undoer: (store): void => {
+		undo: (store): void => {
 			const undoStack = storeMap.get(store) || [];
 			const undo = undoStack.pop();
 			if (undo !== undefined) {
@@ -54,7 +54,7 @@ export function createUndoManager(): UndoManager {
 }
 
 export interface HistoryManager {
-	historyCollector: ProcessCallbackDecorator;
+	collector: ProcessCallbackDecorator;
 	serialize: (store: any) => PatchOperation[][];
 	hydrate: (store: any, history: any[][]) => void;
 }
@@ -62,7 +62,7 @@ export interface HistoryManager {
 export function createHistoryManager(): HistoryManager {
 	const storeMap = new WeakMap();
 	return {
-		historyCollector(callback?: any) {
+		collector(callback?: any) {
 			return (error: ProcessError | null, result: ProcessResult): void => {
 				const { operations, processId, store } = result;
 				const historyStack = storeMap.get(store) || [];

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,5 +1,4 @@
 import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallbackDecorator } from './process';
-import { PatchOperation } from '../src/state/Patch';
 import { Pointer } from '../src/state/Pointer';
 import WeakMap from '@dojo/shim/WeakMap';
 

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -35,6 +35,7 @@ export class HistoryManager {
 		}
 		return false;
 	}
+
 	public canRedo(store: Store): boolean {
 		const stacks = this._storeMap.get(store);
 		if (stacks) {

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -56,7 +56,7 @@ export function createUndoManager(): UndoManager {
 export interface HistoryManager {
 	collector: ProcessCallbackDecorator;
 	serialize: (store: any) => PatchOperation[][];
-	hydrate: (store: any, history: any[][]) => void;
+	deserialize: (store: any, history: any[][]) => void;
 }
 
 export function createHistoryManager(): HistoryManager {
@@ -71,7 +71,7 @@ export function createHistoryManager(): HistoryManager {
 				callback && callback(error, result);
 			};
 		},
-		hydrate(store, history) {
+		deserialize(store, history) {
 			history.forEach(({ processId, operations }: any) => {
 				operations = (operations as any[]).map((operation) => {
 					operation.path = new Pointer(operation.path);

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,11 +1,17 @@
 import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallback } from './process';
+import { PatchOperation } from '../src/state/Patch';
 import { Pointer } from '../src/state/Pointer';
 import Store from '../src/Store';
 import WeakMap from '@dojo/shim/WeakMap';
 
+export interface HistoryOperation {
+	id: string;
+	operations: PatchOperation[];
+}
+
 export interface HistoryData {
-	history: { id: string; operations: any[] }[];
-	redo: { id: string; operations: any[] }[];
+	history: HistoryOperation[];
+	redo: HistoryOperation[];
 }
 
 export class HistoryManager {
@@ -77,8 +83,8 @@ export class HistoryManager {
 
 	public deserialize(store: Store, data: HistoryData) {
 		const { history, redo } = data;
-		history.forEach(({ id, operations }: any) => {
-			operations = (operations as any[]).map((operation) => {
+		history.forEach(({ id, operations }: HistoryOperation) => {
+			operations = operations.map((operation) => {
 				operation.path = new Pointer(operation.path);
 				return operation;
 			});
@@ -90,8 +96,8 @@ export class HistoryManager {
 			processExecutor(id, [() => operations], store, callback, undefined)({});
 		});
 		const stacks = this._storeMap.get(store);
-		redo.forEach(({ id, operations }: any) => {
-			operations = (operations as any[]).map((operation) => {
+		redo.forEach(({ id, operations }: HistoryOperation) => {
+			operations = operations.map((operation) => {
 				operation.path = new Pointer(operation.path);
 				return operation;
 			});

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -81,8 +81,7 @@ export function createHistoryManager(): HistoryManager {
 				if (processId) {
 					const process = getProcess(processId);
 					if (process) {
-						const [, options] = process;
-						callback = options.callback;
+						callback = process[2];
 					}
 				}
 				processExecutor(processId, [() => operations], store, callback, undefined)({});

--- a/src/middleware/HistoryManager.ts
+++ b/src/middleware/HistoryManager.ts
@@ -1,7 +1,7 @@
-import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallback } from './process';
-import { PatchOperation } from '../src/state/Patch';
-import { Pointer } from '../src/state/Pointer';
-import Store from '../src/Store';
+import { processExecutor, getProcess, ProcessError, ProcessResult, ProcessCallback } from '../process';
+import { PatchOperation } from '../../src/state/Patch';
+import { Pointer } from '../../src/state/Pointer';
+import Store from '../../src/Store';
 import WeakMap from '@dojo/shim/WeakMap';
 
 export interface HistoryOperation {

--- a/src/process.ts
+++ b/src/process.ts
@@ -125,11 +125,6 @@ export function createCommandFactory<T, P extends object = DefaultPayload>(): Co
  */
 export type Commands<T = any, P extends object = DefaultPayload> = (Command<T, P>[] | Command<T, P>)[];
 
-export interface ProcessOptions {
-	id?: string;
-	callback?: ProcessCallback;
-}
-
 const processMap = new Map();
 
 export function getProcess(id: string) {

--- a/src/process.ts
+++ b/src/process.ts
@@ -72,6 +72,7 @@ export interface ProcessResult<T = any, P extends object = DefaultPayload> exten
 	store: Store<any>;
 	undo: Undo;
 	operations: PatchOperation<T>[];
+	undoOperations: PatchOperation<T>[];
 	apply: (operations: PatchOperation<T>[], invalidate?: boolean) => PatchOperation<T>[];
 	payload: P;
 	error?: ProcessError<T> | null;
@@ -190,9 +191,22 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 		}
 
 		callback &&
-			callback(error, { store, processId: id, operations, undo, apply, at, get, path, executor, payload });
+			callback(error, {
+				undoOperations,
+				store,
+				processId: id,
+				operations,
+				undo,
+				apply,
+				at,
+				get,
+				path,
+				executor,
+				payload
+			});
 		return Promise.resolve({
 			store,
+			undoOperations,
 			processId: id,
 			error,
 			operations,

--- a/src/process.ts
+++ b/src/process.ts
@@ -70,7 +70,6 @@ export interface ProcessResultExecutor<T = any> {
 export interface ProcessResult<T = any, P extends object = DefaultPayload> extends State<T> {
 	executor: ProcessResultExecutor<T>;
 	store: Store<any>;
-	undo: Undo;
 	operations: PatchOperation<T>[];
 	undoOperations: PatchOperation<T>[];
 	apply: (operations: PatchOperation<T>[], invalidate?: boolean) => PatchOperation<T>[];
@@ -157,10 +156,6 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 		const undoOperations: PatchOperation[] = [];
 		const operations: PatchOperation[] = [];
 		const commandsCopy = [...commands];
-		const undo = () => {
-			store.apply(undoOperations, true);
-		};
-
 		let command = commandsCopy.shift();
 		let error: ProcessError | null = null;
 		const payload = transformer ? transformer(executorPayload) : executorPayload;
@@ -196,7 +191,6 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 				store,
 				processId: id,
 				operations,
-				undo,
 				apply,
 				at,
 				get,
@@ -210,7 +204,6 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 			processId: id,
 			error,
 			operations,
-			undo,
 			apply,
 			at,
 			get,

--- a/src/process.ts
+++ b/src/process.ts
@@ -75,7 +75,7 @@ export interface ProcessResult<T = any, P extends object = DefaultPayload> exten
 	apply: (operations: PatchOperation<T>[], invalidate?: boolean) => PatchOperation<T>[];
 	payload: P;
 	error?: ProcessError<T> | null;
-	processId?: string;
+	id?: string;
 }
 
 /**
@@ -184,7 +184,7 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 			callback(error, {
 				undoOperations,
 				store,
-				processId: id,
+				id,
 				operations,
 				apply,
 				at,
@@ -196,7 +196,7 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 		return Promise.resolve({
 			store,
 			undoOperations,
-			processId: id,
+			id,
 			error,
 			operations,
 			apply,
@@ -219,9 +219,7 @@ export function createProcess<T = any, P extends object = DefaultPayload>(
 	commands: Commands<T, P>,
 	callback?: ProcessCallback
 ): Process<T, P> {
-	if (id) {
-		processMap.set(id, [id, commands, callback]);
-	}
+	processMap.set(id, [id, commands, callback]);
 	return (store: Store<T>, transformer?: Transformer<P>) =>
 		processExecutor(id, commands, store, callback, transformer);
 }

--- a/src/process.ts
+++ b/src/process.ts
@@ -69,13 +69,13 @@ export interface ProcessResultExecutor<T = any> {
  */
 export interface ProcessResult<T = any, P extends object = DefaultPayload> extends State<T> {
 	executor: ProcessResultExecutor<T>;
-	store: Store<any>;
+	store: Store<T>;
 	operations: PatchOperation<T>[];
 	undoOperations: PatchOperation<T>[];
 	apply: (operations: PatchOperation<T>[], invalidate?: boolean) => PatchOperation<T>[];
 	payload: P;
+	id: string;
 	error?: ProcessError<T> | null;
-	id?: string;
 }
 
 /**

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,6 +1,7 @@
 import { isThenable } from '@dojo/shim/Promise';
 import { PatchOperation } from './state/Patch';
 import { State, Store } from './Store';
+import Map from '@dojo/shim/Map';
 
 /**
  * Default Payload interface
@@ -129,10 +130,10 @@ export interface ProcessOptions {
 	callback?: ProcessCallback;
 }
 
-const ids: any = {};
+const processMap = new Map();
 
 export function getProcess(id: string) {
-	return ids[id];
+	return processMap.get(id);
 }
 
 export function processExecutor<T = any, P extends object = DefaultPayload>(
@@ -217,7 +218,7 @@ export function createProcess<T = any, P extends object = DefaultPayload>(
 	callback?: ProcessCallback
 ): Process<T, P> {
 	if (id) {
-		ids[id] = [commands, { id, callback }];
+		processMap.set(id, [id, commands, callback]);
 	}
 	return (store: Store<T>, transformer?: Transformer<P>) =>
 		processExecutor(id, commands, store, callback, transformer);

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -81,7 +81,7 @@ export class Pointer<T = any, U = any> {
 		return pointerTarget.target[pointerTarget.segment];
 	}
 
-	toJSON() {
+	toJSON(): string {
 		return this.path;
 	}
 }

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -82,6 +82,10 @@ export class Pointer<T = any, U = any> {
 	}
 
 	toJSON(): string {
+		return this.toString();
+	}
+
+	toString(): string {
 		return this.path;
 	}
 }

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -80,4 +80,8 @@ export class Pointer<T = any, U = any> {
 		const pointerTarget: PointerTarget = walk(this.segments, object, false);
 		return pointerTarget.target[pointerTarget.segment];
 	}
+
+	toJSON() {
+		return this.path;
+	}
 }

--- a/tests/unit/StoreInjector.ts
+++ b/tests/unit/StoreInjector.ts
@@ -36,8 +36,8 @@ describe('StoreInjector', () => {
 	beforeEach(() => {
 		registry = new Registry();
 		store = new Store<State>();
-		fooProcess = createProcess([fooCommand]);
-		barProcess = createProcess([barCommand]);
+		fooProcess = createProcess('foo', [fooCommand]);
+		barProcess = createProcess('bar', [barCommand]);
 	});
 
 	describe('StoreInjector', () => {

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,4 +1,4 @@
-import './extras';
+import './middleware/HistoryManager';
 import './Store';
 import './process';
 import './state/all';

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -53,6 +53,19 @@ describe('extras', () => {
 
 		// histories should now be identical
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
+
+		historyManager.redo(store);
+		assert.strictEqual(store.get(store.path('counter')), 2);
+
+		historyManager.redo(store);
+		assert.strictEqual(store.get(store.path('counter')), 3);
+
+		historyManager.undo(store);
+		assert.strictEqual(store.get(store.path('counter')), 2);
+
+		executor({});
+		assert.isFalse(historyManager.canRedo(store));
+		assert.strictEqual(store.get(store.path('counter')), 3);
 	});
 
 	it('can undo', () => {

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -33,12 +33,10 @@ describe('extras', () => {
 
 		// serialize the history
 		const json = JSON.stringify(historyManager.serialize(store));
-		// deserialize it
-		const history = JSON.parse(json);
 		// create a new store
 		const storeCopy = new Store();
-		// hydrate the new store with the history
-		historyManager.hydrate(storeCopy, history);
+		// deserialize the new store with the history
+		historyManager.deserialize(storeCopy, JSON.parse(json));
 		// should be re-hydrated
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 3);
 		// can undo the history
@@ -46,6 +44,8 @@ describe('extras', () => {
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		undoManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 1);
+		// storeCopy history is identical to original store history
+		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
 	});
 
 	it('collects undo functions for all processes using collector', () => {

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -13,7 +13,7 @@ function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): P
 }
 
 describe('extras', () => {
-	it('can serialize and re-hydrate history non destructively', () => {
+	it('can serialize and deserialize history', () => {
 		const historyManager = createHistoryManager();
 		const store = new Store();
 
@@ -55,7 +55,7 @@ describe('extras', () => {
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
 	});
 
-	it('collects undo functions for all processes using collector', () => {
+	it('can undo', () => {
 		const historyManager = createHistoryManager();
 		const store = new Store();
 		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.collector());

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -48,6 +48,7 @@ describe('extras', () => {
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 1);
 		assert.strictEqual(historyManager.serialize(storeCopy).history.length, 1);
 		// can redo on new StoreCopy
+		historyManager.canRedo(storeCopy);
 		historyManager.redo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		// undo on original store

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -12,12 +12,22 @@ function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): P
 	return [{ op: OperationType.REPLACE, path: new Pointer('/counter'), value: ++counter }];
 }
 
+function collector(callback?: any): any {
+	return (error: any, result: any): void => {
+		callback && callback(error, result);
+	};
+}
+
 describe('extras', () => {
 	it('can serialize and deserialize history', () => {
 		const historyManager = new HistoryManager();
 		const store = new Store();
 
-		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.collector());
+		const incrementCounterProcess = createProcess(
+			'increment',
+			[incrementCounter],
+			historyManager.collector(collector)
+		);
 		const executor = incrementCounterProcess(store);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -30,58 +30,39 @@ describe('extras', () => {
 		const json = JSON.stringify(historyManager.serialize(store));
 		// create a new store
 		const storeCopy = new Store();
+		// cannot undo nothing
+		assert.isFalse(historyManager.canUndo(storeCopy));
+		// cannot redo nothing
+		assert.isFalse(historyManager.canRedo(storeCopy));
 		// deserialize the new store with the history
 		historyManager.deserialize(storeCopy, JSON.parse(json));
 		// should be re-hydrated
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 3);
 		// storeCopy history is identical to original store history
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
-
 		// can undo on new storeCopy
+		assert.isTrue(historyManager.canUndo(storeCopy));
 		historyManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		historyManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 1);
-		// history should now be 1 item
 		assert.strictEqual(historyManager.serialize(storeCopy).history.length, 1);
-
+		// can redo on new StoreCopy
+		historyManager.redo(storeCopy);
+		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		// undo on original store
 		historyManager.undo(store);
 		assert.strictEqual(store.get(store.path('counter')), 2);
 		historyManager.undo(store);
 		assert.strictEqual(storeCopy.get(store.path('counter')), 1);
-
+		// redo on original store
+		historyManager.redo(store);
+		assert.strictEqual(store.get(store.path('counter')), 2);
 		// histories should now be identical
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
-
-		historyManager.redo(store);
-		assert.strictEqual(store.get(store.path('counter')), 2);
-
-		historyManager.redo(store);
-		assert.strictEqual(store.get(store.path('counter')), 3);
-
-		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 2);
-
+		// adding to history nukes redo
 		executor({});
-		// redo is nuked when a process is ran
 		assert.isFalse(historyManager.canRedo(store));
-		assert.strictEqual(store.get(store.path('counter')), 3);
-
-		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 2);
-
-		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 1);
-
-		const foo = JSON.stringify(historyManager.serialize(store));
-		const anotherStoreCopy = new Store();
-		historyManager.deserialize(anotherStoreCopy, JSON.parse(foo));
-
-		// carries over redo history
-		assert.isTrue(historyManager.canRedo(anotherStoreCopy));
-		historyManager.redo(anotherStoreCopy);
-		assert.strictEqual(anotherStoreCopy.get(anotherStoreCopy.path('counter')), 2);
 	});
 
 	it('can undo', () => {

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -26,7 +26,7 @@ describe('extras', () => {
 		const incrementCounterProcess = createProcess(
 			'increment',
 			[incrementCounter],
-			historyManager.collector(collector)
+			historyManager.collector(collector())
 		);
 		const executor = incrementCounterProcess(store);
 		executor({});

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -2,7 +2,7 @@ const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
 import { OperationType, PatchOperation } from './../../src/state/Patch';
-import { CommandRequest, createProcess, ProcessError, ProcessResult } from './../../src/process';
+import { CommandRequest, createProcess } from './../../src/process';
 import { Pointer } from './../../src/state/Pointer';
 import { createUndoManager, createHistoryManager } from './../../src/extras';
 import { Store } from './../../src/Store';
@@ -18,16 +18,10 @@ describe('extras', () => {
 		const { historyCollector, serialize, hydrate } = createHistoryManager();
 		const store = new Store();
 
-		const logger = (callback?: any) => {
-			return (error: ProcessError | null, result: ProcessResult): void => {
-				console.log('-------> set counter to', (result.operations[0] as any).value);
-				callback && callback(error, result);
-			};
-		};
 		const incrementCounterProcess = createProcess(
 			'increment',
 			[incrementCounter],
-			historyCollector(undoCollector(logger()))
+			historyCollector(undoCollector())
 		);
 		const executor = incrementCounterProcess(store);
 		executor({});

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -36,7 +36,8 @@ describe('extras', () => {
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 3);
 		// storeCopy history is identical to original store history
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
-		// can undo the history
+
+		// can undo on new storeCopy
 		historyManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		historyManager.undo(storeCopy);
@@ -49,8 +50,8 @@ describe('extras', () => {
 		assert.strictEqual(store.get(store.path('counter')), 2);
 		historyManager.undo(store);
 		assert.strictEqual(storeCopy.get(store.path('counter')), 1);
+
 		// histories should now be identical
-		// history should now be 1 item
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
 	});
 

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { OperationType, PatchOperation } from './../../src/state/Patch';
 import { CommandRequest, createProcess } from './../../src/process';
 import { Pointer } from './../../src/state/Pointer';
-import { createHistoryManager } from './../../src/extras';
+import HistoryManager from './../../src/extras';
 import { Store } from './../../src/Store';
 
 function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): PatchOperation[] {
@@ -14,7 +14,7 @@ function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): P
 
 describe('extras', () => {
 	it('can serialize and deserialize history', () => {
-		const historyManager = createHistoryManager();
+		const historyManager = new HistoryManager();
 		const store = new Store();
 
 		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.collector());

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -64,29 +64,4 @@ describe('extras', () => {
 		executor({});
 		assert.isFalse(historyManager.canRedo(store));
 	});
-
-	it('can undo', () => {
-		const historyManager = createHistoryManager();
-		const store = new Store();
-		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.collector());
-		const executor = incrementCounterProcess(store);
-		executor({});
-		assert.strictEqual(store.get(store.path('counter')), 1);
-		executor({});
-		assert.strictEqual(store.get(store.path('counter')), 2);
-		executor({});
-		assert.strictEqual(store.get(store.path('counter')), 3);
-		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 2);
-	});
-
-	it('undo has no effect if there are no undo functions on the stack', () => {
-		const historyManager = createHistoryManager();
-		const store = new Store();
-		const incrementCounterProcess = createProcess('increment', [incrementCounter]);
-		const executor = incrementCounterProcess(store);
-		executor({});
-		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 1);
-	});
 });

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -55,17 +55,10 @@ describe('extras', () => {
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
 	});
 
-	/*it('collects undo functions for all processes using collector', () => {
-		const undoManager = createUndoManager();
+	it('collects undo functions for all processes using collector', () => {
+		const historyManager = createHistoryManager();
 		const store = new Store();
-		let localUndoStack: any[] = [];
-		const incrementCounterProcess = createProcess(
-			'increment',
-			[incrementCounter],
-			undoManager.collector((error, result) => {
-				localUndoStack.push(result.undo);
-			})
-		);
+		const incrementCounterProcess = createProcess('increment', [incrementCounter], historyManager.collector());
 		const executor = incrementCounterProcess(store);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 1);
@@ -73,43 +66,17 @@ describe('extras', () => {
 		assert.strictEqual(store.get(store.path('counter')), 2);
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 3);
-		localUndoStack[2]();
+		historyManager.undo(store);
 		assert.strictEqual(store.get(store.path('counter')), 2);
-		undoManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 1);
 	});
 
 	it('undo has no effect if there are no undo functions on the stack', () => {
-		const undoManager = createUndoManager();
+		const historyManager = createHistoryManager();
 		const store = new Store();
 		const incrementCounterProcess = createProcess('increment', [incrementCounter]);
 		const executor = incrementCounterProcess(store);
 		executor({});
-		undoManager.undo(store);
+		historyManager.undo(store);
 		assert.strictEqual(store.get(store.path('counter')), 1);
 	});
-
-	it('local undo throws an error if global undo has already been executed', () => {
-		const undoManager = createUndoManager();
-		const store = new Store();
-		let localUndo: any;
-		const incrementCounterProcess = createProcess(
-			'increment',
-			[incrementCounter],
-			undoManager.collector((error, result) => {
-				localUndo = result.undo;
-			})
-		);
-		const executor = incrementCounterProcess(store);
-		executor({});
-		assert.strictEqual(store.get(store.path('counter')), 1);
-		undoManager.undo(store);
-		assert.throws(
-			() => {
-				localUndo && localUndo();
-			},
-			Error,
-			'Test operation failure. Unable to apply any operations.'
-		);
-	});*/
 });

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -26,6 +26,7 @@ describe('extras', () => {
 		executor({});
 		assert.strictEqual(store.get(store.path('counter')), 3);
 
+		historyManager.undo(store);
 		// serialize the history
 		const json = JSON.stringify(historyManager.serialize(store));
 		// create a new store
@@ -37,13 +38,11 @@ describe('extras', () => {
 		// deserialize the new store with the history
 		historyManager.deserialize(storeCopy, JSON.parse(json));
 		// should be re-hydrated
-		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 3);
+		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		// storeCopy history is identical to original store history
 		assert.deepEqual(historyManager.serialize(store), historyManager.serialize(storeCopy));
 		// can undo on new storeCopy
 		assert.isTrue(historyManager.canUndo(storeCopy));
-		historyManager.undo(storeCopy);
-		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		historyManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 1);
 		assert.strictEqual(historyManager.serialize(storeCopy).history.length, 1);
@@ -53,9 +52,7 @@ describe('extras', () => {
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 2);
 		// undo on original store
 		historyManager.undo(store);
-		assert.strictEqual(store.get(store.path('counter')), 2);
-		historyManager.undo(store);
-		assert.strictEqual(storeCopy.get(store.path('counter')), 1);
+		assert.strictEqual(store.get(store.path('counter')), 1);
 		// redo on original store
 		historyManager.redo(store);
 		assert.strictEqual(store.get(store.path('counter')), 2);

--- a/tests/unit/extras.ts
+++ b/tests/unit/extras.ts
@@ -43,7 +43,7 @@ describe('extras', () => {
 		historyManager.undo(storeCopy);
 		assert.strictEqual(storeCopy.get(storeCopy.path('counter')), 1);
 		// history should now be 1 item
-		assert.strictEqual(historyManager.serialize(storeCopy).length, 1);
+		assert.strictEqual(historyManager.serialize(storeCopy).history.length, 1);
 
 		// undo on original store
 		historyManager.undo(store);
@@ -64,8 +64,24 @@ describe('extras', () => {
 		assert.strictEqual(store.get(store.path('counter')), 2);
 
 		executor({});
+		// redo is nuked when a process is ran
 		assert.isFalse(historyManager.canRedo(store));
 		assert.strictEqual(store.get(store.path('counter')), 3);
+
+		historyManager.undo(store);
+		assert.strictEqual(store.get(store.path('counter')), 2);
+
+		historyManager.undo(store);
+		assert.strictEqual(store.get(store.path('counter')), 1);
+
+		const foo = JSON.stringify(historyManager.serialize(store));
+		const anotherStoreCopy = new Store();
+		historyManager.deserialize(anotherStoreCopy, JSON.parse(foo));
+
+		// carries over redo history
+		assert.isTrue(historyManager.canRedo(anotherStoreCopy));
+		historyManager.redo(anotherStoreCopy);
+		assert.strictEqual(anotherStoreCopy.get(anotherStoreCopy.path('counter')), 2);
 	});
 
 	it('can undo', () => {

--- a/tests/unit/middleware/HistoryManager.ts
+++ b/tests/unit/middleware/HistoryManager.ts
@@ -1,11 +1,11 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import { OperationType, PatchOperation } from './../../src/state/Patch';
-import { CommandRequest, createProcess } from './../../src/process';
-import { Pointer } from './../../src/state/Pointer';
-import HistoryManager from './../../src/extras';
-import { Store } from './../../src/Store';
+import { OperationType, PatchOperation } from './../../../src/state/Patch';
+import { CommandRequest, createProcess } from './../../../src/process';
+import { Pointer } from './../../../src/state/Pointer';
+import HistoryManager from './../../../src/middleware/HistoryManager';
+import { Store } from './../../../src/Store';
 
 function incrementCounter({ get, path }: CommandRequest<{ counter: number }>): PatchOperation[] {
 	let counter = get(path('counter')) || 0;

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -57,7 +57,7 @@ describe('process', () => {
 	});
 
 	it('with synchronous commands running in order', () => {
-		const process = createProcess([testCommandFactory('foo'), testCommandFactory('foo/bar')]);
+		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('foo/bar')]);
 		const processExecutor = process(store);
 		processExecutor({});
 		const foo = store.get(store.path('foo'));
@@ -67,7 +67,7 @@ describe('process', () => {
 	});
 
 	it('processes wait for asynchronous commands to complete before continuing', () => {
-		const process = createProcess([
+		const process = createProcess('test', [
 			testCommandFactory('foo'),
 			testAsyncCommandFactory('bar'),
 			testCommandFactory('foo/bar')
@@ -90,7 +90,7 @@ describe('process', () => {
 	});
 
 	it('support concurrent commands executed synchronously', () => {
-		const process = createProcess([
+		const process = createProcess('test', [
 			testCommandFactory('foo'),
 			[testAsyncCommandFactory('bar'), testAsyncCommandFactory('baz')],
 			testCommandFactory('foo/bar')
@@ -114,7 +114,7 @@ describe('process', () => {
 	});
 
 	it('passes the payload to each command', () => {
-		const process = createProcess([
+		const process = createProcess('test', [
 			testCommandFactory('foo'),
 			testCommandFactory('bar'),
 			testCommandFactory('baz')
@@ -130,7 +130,7 @@ describe('process', () => {
 	});
 
 	it('can use a transformer for the arguments passed to the process executor', () => {
-		const process = createProcess<any, { foo: string }>([
+		const process = createProcess<any, { foo: string }>('test', [
 			testCommandFactory('foo'),
 			testCommandFactory('bar'),
 			testCommandFactory('baz')
@@ -174,11 +174,11 @@ describe('process', () => {
 		const commandOne = createCommandOne(({ get, path, payload }) => []);
 		const commandTwo = createCommandTwo(({ get, path, payload }) => []);
 		const commandThree = createCommandThree(({ get, path, payload }) => []);
-		const processOne = createProcess<any, { foo: string; bar: string }>([commandOne, commandTwo]);
-		// createProcess([commandOne, commandTwo]); // shouldn't compile
+		const processOne = createProcess<any, { foo: string; bar: string }>('test', [commandOne, commandTwo]);
+		// createProcess('test', [commandOne, commandTwo]); // shouldn't compile
 		// createProcess<any, { bar: string }>([commandOne]); // shouldn't compile
-		const processTwo = createProcess([commandTwo]);
-		const processThree = createProcess([commandThree]);
+		const processTwo = createProcess('test', [commandTwo]);
+		const processThree = createProcess('test', [commandThree]);
 		const executorOne = processOne(store);
 		const executorTwo = processTwo(store);
 		const executorThree = processThree(store);
@@ -211,8 +211,8 @@ describe('process', () => {
 			};
 		};
 
-		const processOne = createProcess([commandOne]);
-		const processTwo = createProcess<any, { bar: number; foo: number }>([commandOne, commandTwo]);
+		const processOne = createProcess('test', [commandOne]);
+		const processTwo = createProcess<any, { bar: number; foo: number }>('test', [commandOne, commandTwo]);
 		const processOneResult = processOne(store, transformerOne)({ foo: '' });
 		// processTwo(store, transformerOne); // compile error
 		const processTwoResult = processTwo(store, transformerTwo)({ foo: 3 });
@@ -236,10 +236,8 @@ describe('process', () => {
 
 	it('can provide a callback that gets called on process completion', () => {
 		let callbackCalled = false;
-		const process = createProcess([testCommandFactory('foo')], {
-			callback: () => {
-				callbackCalled = true;
-			}
+		const process = createProcess('test', [testCommandFactory('foo')], () => {
+			callbackCalled = true;
 		});
 		const processExecutor = process(store);
 		processExecutor({});
@@ -247,41 +245,35 @@ describe('process', () => {
 	});
 
 	it('when a command errors, the error and command is returned in the error argument of the callback', () => {
-		const process = createProcess([testCommandFactory('foo'), testErrorCommand], {
-			callback: (error) => {
-				assert.isNotNull(error);
-				assert.strictEqual(error && error.command, testErrorCommand);
-			}
+		const process = createProcess('test', [testCommandFactory('foo'), testErrorCommand], (error) => {
+			assert.isNotNull(error);
+			assert.strictEqual(error && error.command, testErrorCommand);
 		});
 		const processExecutor = process(store);
 		processExecutor({});
 	});
 
 	it('executor can be used to programmatically run additional processes', () => {
-		const extraProcess = createProcess([testCommandFactory('bar')]);
-		const process = createProcess([testCommandFactory('foo')], {
-			callback: (error, result) => {
-				assert.isNull(error);
-				let bar = store.get(store.path('bar'));
-				assert.isUndefined(bar);
-				result.executor(extraProcess, {});
-				bar = store.get(store.path('bar'));
-				assert.strictEqual(bar, 'bar');
-			}
+		const extraProcess = createProcess('test', [testCommandFactory('bar')]);
+		const process = createProcess('test', [testCommandFactory('foo')], (error, result) => {
+			assert.isNull(error);
+			let bar = store.get(store.path('bar'));
+			assert.isUndefined(bar);
+			result.executor(extraProcess, {});
+			bar = store.get(store.path('bar'));
+			assert.strictEqual(bar, 'bar');
 		});
 		const processExecutor = process(store);
 		processExecutor({});
 	});
 
 	it('process can be undone using the undo function provided via the callback', () => {
-		const process = createProcess([testCommandFactory('foo')], {
-			callback: (error, result) => {
-				let foo = store.get(store.path('foo'));
-				assert.strictEqual(foo, 'foo');
-				result.undo();
-				foo = store.get(store.path('foo'));
-				assert.isUndefined(foo);
-			}
+		const process = createProcess('test', [testCommandFactory('foo')], (error, result) => {
+			let foo = store.get(store.path('foo'));
+			assert.strictEqual(foo, 'foo');
+			result.undo();
+			foo = store.get(store.path('foo'));
+			assert.isUndefined(foo);
 		});
 		const processExecutor = process(store);
 		processExecutor({});
@@ -315,7 +307,7 @@ describe('process', () => {
 			createCallbackDecorator(logPointerCallback)
 		]);
 
-		const process = createProcess([testCommandFactory('foo'), testCommandFactory('bar')]);
+		const process = createProcess('test', [testCommandFactory('foo'), testCommandFactory('bar')]);
 		const executor = process(store);
 		executor({});
 		assert.lengthOf(results, 2);

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -267,18 +267,6 @@ describe('process', () => {
 		processExecutor({});
 	});
 
-	it('process can be undone using the undo function provided via the callback', () => {
-		const process = createProcess('test', [testCommandFactory('foo')], (error, result) => {
-			let foo = store.get(store.path('foo'));
-			assert.strictEqual(foo, 'foo');
-			result.undo();
-			foo = store.get(store.path('foo'));
-			assert.isUndefined(foo);
-		});
-		const processExecutor = process(store);
-		processExecutor({});
-	});
-
 	it('Creating a process returned automatically decorates all process callbacks', () => {
 		let results: string[] = [];
 

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -310,4 +310,16 @@ describe('process', () => {
 		assert.strictEqual(results[3], 'callback one');
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
 	});
+
+	it('process can be undone using the undo function provided via the callback', () => {
+		const process = createProcess('foo', [testCommandFactory('foo')], (error, result) => {
+			let foo = store.get(result.store.path('foo'));
+			assert.strictEqual(foo, 'foo');
+			store.apply(result.undoOperations);
+			foo = store.get(result.store.path('foo'));
+			assert.isUndefined(foo);
+		});
+		const processExecutor = process(store);
+		processExecutor({});
+	});
 });

--- a/tests/unit/state/Pointer.ts
+++ b/tests/unit/state/Pointer.ts
@@ -95,4 +95,10 @@ describe('state/Pointer', () => {
 		assert.deepEqual(target.target, {});
 		assert.deepEqual(target.segment, 'qux');
 	});
+
+	it('converts to a string path with toJSON', () => {
+		const pointer = new Pointer('foo/bar/qux');
+		const stringified = JSON.stringify(pointer);
+		assert.strictEqual(stringified, '"/foo/bar/qux"');
+	});
 });

--- a/tests/unit/state/Pointer.ts
+++ b/tests/unit/state/Pointer.ts
@@ -99,7 +99,7 @@ describe('state/Pointer', () => {
 	it('converts to a string path with toString', () => {
 		const pointer = new Pointer('foo/bar/qux');
 		const stringified = pointer.toString();
-		assert.strictEqual(stringified, '"/foo/bar/qux"');
+		assert.strictEqual(stringified, '/foo/bar/qux');
 	});
 
 	it('converts to a string path with toJSON', () => {

--- a/tests/unit/state/Pointer.ts
+++ b/tests/unit/state/Pointer.ts
@@ -96,6 +96,12 @@ describe('state/Pointer', () => {
 		assert.deepEqual(target.segment, 'qux');
 	});
 
+	it('converts to a string path with toString', () => {
+		const pointer = new Pointer('foo/bar/qux');
+		const stringified = pointer.toString();
+		assert.strictEqual(stringified, '"/foo/bar/qux"');
+	});
+
 	it('converts to a string path with toJSON', () => {
 		const pointer = new Pointer('foo/bar/qux');
 		const stringified = JSON.stringify(pointer);

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
-		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Refactors the undo manager to be a more a generic history manager. This mvp currently allows serialization and deserialization of an entire history, as well as undo'ing and redo'ing.

I made a few breaking changes: 
* the undo manager no longer exists, as the history manager is a superset of it's functionality.
* we have to take an `id` when creating a process. this is so we can trace the middleware/callbacks used for each process and re-apply them when we deserialize. Having to provide an `id` is a little annoying, but in the long run it will also help us for tracing other things (like in the dev tools).
* i removed `ProcessOptions`, in favour of just providing the callback. In a subsequent PR we should rename `callback` to `middleware`. If we ever do need options on a Process, they would be separate from the middleware anyway.
* an undoer function is no longer provided in the `ProcessResult`, this is because it's difficult to sync changes with the history manager (the undo manager used to overwrite the undoer function, which we could do again but it is ugly). we do provide `undoOperations` and the `store` on the `ProcessResult` now though, so if you do not care about the history manager you can manually apply the `undoOperations` to get the same effect.

I need to fix up some of the loose typings, some missing tests and update the README.


Resolves #???
