### PR TITLE
Allow StoreContainer to be typed directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Store data can be connected to widgets within your application using the [Contai
 ```ts
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { Store } from '@dojo/stores/Stores';
-import { StoreInjector, StoreContainer } from '@dojo/stores/StoreInjector';
+import { StoreContainer } from '@dojo/stores/StoreInjector';
 
 interface State {
 	foo: string;
@@ -395,21 +395,21 @@ interface State {
 }
 
 // Will only invalidate when the foo property is changed
-const Container = Container(WidgetBase, 'state', { paths: [ [ 'foo' ] ], getProperties(store: Store<State>) {
+const Container = StoreContainer<State>(WidgetBase, 'state', { paths: [ [ 'foo' ] ], getProperties(store: Store<State>) {
 	return {
 		foo: store.get(store.path('foo'))
 	}
 }});
 
 // Catch all, will invalidate if _any_ state changes in the store even if the container is not interested in the changes
-const Container = Container(WidgetBase, 'state', { getProperties(store: Store<State>) {
+const Container = StoreContainer<State>(WidgetBase, 'state', { getProperties(store: Store<State>) {
 	return {
 		foo: store.get(store.path('foo'))
 	}
 }});
 ```
 
-To provide a typed container for the store's state, use the `createStoreContainer` function from `@dojo/stores/StoreInjector` passing in the state interface as a generic and then export the returned `Container` to be available throughout your application.
+To provide a create typed container for the store's state, use the `createStoreContainer` function from `@dojo/stores/StoreInjector` passing in the state interface as a generic and then export the returned `Container` to be available throughout your application.
 
 ```ts
 interface State {

--- a/README.md
+++ b/README.md
@@ -409,14 +409,14 @@ const Container = StoreContainer<State>(WidgetBase, 'state', { getProperties(sto
 }});
 ```
 
-To provide a create typed container for the store's state, use the `createStoreContainer` function from `@dojo/stores/StoreInjector` passing in the state interface as a generic and then export the returned `Container` to be available throughout your application.
+Instead of typing `StoreContainer` for every usage, it is possible to create a pre-typed StoreContainer that can be used across your application. To do this use `createStoreContainer` from `@dojo/stores/StoreInjector` passing the stores state interface as the generic argument. The result of this can be exported and used across your application.
 
 ```ts
 interface State {
 	foo: string;
 }
 
-const StoreContainer = createStoreContainer<State>();
+export const StoreContainer = createStoreContainer<State>();
 ```
 
 ### Transforming Executor Arguments

--- a/src/StoreInjector.ts
+++ b/src/StoreInjector.ts
@@ -95,7 +95,7 @@ export class StoreInjector<T = any> extends Injector {
 	}
 }
 
-export function StoreContainer<S, W extends WidgetBase<any, any> = WidgetBase<any, any>>(
+export function StoreContainer<S = any, W extends WidgetBase<any, any> = WidgetBase<any, any>>(
 	component: Constructor<W> | RegistryLabel,
 	name: RegistryLabel,
 	{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>> }

--- a/src/StoreInjector.ts
+++ b/src/StoreInjector.ts
@@ -95,27 +95,30 @@ export class StoreInjector<T = any> extends Injector {
 	}
 }
 
+export function StoreContainer<S, W extends WidgetBase<any, any> = WidgetBase<any, any>>(
+	component: Constructor<W> | RegistryLabel,
+	name: RegistryLabel,
+	{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>> }
+): StoreContainer<W> {
+	@alwaysRender()
+	@storeInject({ name, paths, getProperties })
+	class WidgetContainer extends WidgetBase<Partial<W['properties']>, W['children'][0]> {
+		protected render(): DNode {
+			return w(component, this.properties, this.children);
+		}
+	}
+	return WidgetContainer;
+}
+
 /**
  * Creates a typed `StoreContainer` for State generic.
  */
 export function createStoreContainer<S>() {
-	return function<W extends WidgetBase<any, any>>(
+	return <W extends WidgetBase<any, any>>(
 		component: Constructor<W> | RegistryLabel,
 		name: RegistryLabel,
 		{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>> }
-	): StoreContainer<W> {
-		@alwaysRender()
-		@storeInject({ name, paths, getProperties })
-		class WidgetContainer extends WidgetBase<Partial<W['properties']>, W['children'][0]> {
-			protected render(): DNode {
-				return w(component, this.properties, this.children);
-			}
-		}
-		return WidgetContainer;
+	) => {
+		return StoreContainer(component, name, { paths, getProperties });
 	};
 }
-
-/**
- * Exports an untyped `StoreContainer`
- */
-export const StoreContainer = createStoreContainer();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fix code example in README and enable `StoreContainer` to be typed directly via a generic.

Resolves #165 
