### PR TITLE
Add undo operations on to the stack in the correct order.

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -148,9 +148,9 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 	}
 
 	return async (executorPayload: P): Promise<ProcessResult<T, P>> => {
-		const undoOperations: PatchOperation[] = [];
 		const operations: PatchOperation[] = [];
 		const commandsCopy = [...commands];
+		let undoOperations: PatchOperation[] = [];
 		let command = commandsCopy.shift();
 		let error: ProcessError | null = null;
 		const payload = transformer ? transformer(executorPayload) : executorPayload;
@@ -170,7 +170,7 @@ export function processExecutor<T = any, P extends object = DefaultPayload>(
 
 				for (let i = 0; i < results.length; i++) {
 					operations.push(...results[i]);
-					undoOperations.push(...apply(results[i]));
+					undoOperations = [...apply(results[i]), ...undoOperations];
 				}
 
 				store.invalidate();

--- a/tests/unit/process.ts
+++ b/tests/unit/process.ts
@@ -311,7 +311,7 @@ describe('process', () => {
 		assert.deepEqual(store.get(store.path('logs')), [['/foo', '/bar'], ['/foo', '/bar']]);
 	});
 
-	it('process can be undone using the undo function provided via the callback', async () => {
+	it('process can be undone using the undo function provided via the callback', () => {
 		const command = ({ payload }: CommandRequest): PatchOperation[] => {
 			return [{ op: OperationType.REPLACE, path: new Pointer('/foo'), value: 'bar' }];
 		};
@@ -323,6 +323,6 @@ describe('process', () => {
 			assert.isUndefined(foo);
 		});
 		const processExecutor = process(store);
-		await processExecutor({}).catch(() => assert.fail());
+		return processExecutor({});
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add undo operations to the beginning of the stack when running a `process`

Resolves #175 
