### PR TITLE
Undo operations order bug

### DIFF
--- a/src/state/Patch.ts
+++ b/src/state/Patch.ts
@@ -158,11 +158,7 @@ export class Patch<T = any> {
 				case OperationType.TEST:
 					const result = test(pointerTarget, next.value);
 					if (!result) {
-						throw new Error(
-							`Test operation failure. Unable to apply ${JSON.stringify(
-								next
-							)} operation against ${JSON.stringify(pointerTarget.object)}.`
-						);
+						throw new Error('Test operation failure. Unable to apply any operations.');
 					}
 					return patchedObject;
 				default:

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -34,6 +34,7 @@ export function walk(segments: string[], object: any, clone = true, continueOnUn
 			let target = pointerTarget.target[segment];
 
 			if (target === undefined && !continueOnUndefined) {
+				pointerTarget.target = undefined;
 				return pointerTarget;
 			}
 

--- a/src/state/Pointer.ts
+++ b/src/state/Pointer.ts
@@ -12,7 +12,7 @@ export interface PointerTarget {
 	segment: string;
 }
 
-export function walk(segments: string[], object: any, clone = true): PointerTarget {
+export function walk(segments: string[], object: any, clone = true, continueOnUndefined = true): PointerTarget {
 	if (clone) {
 		object = { ...object };
 	}
@@ -23,12 +23,19 @@ export function walk(segments: string[], object: any, clone = true): PointerTarg
 	};
 
 	return segments.reduce((pointerTarget, segment, index) => {
+		if (pointerTarget.target === undefined) {
+			return pointerTarget;
+		}
 		if (Array.isArray(pointerTarget.target) && segment === '-') {
 			segment = String(pointerTarget.target.length - 1);
 		}
 		if (index + 1 < segments.length) {
 			const nextSegment = segments[index + 1];
 			let target = pointerTarget.target[segment];
+
+			if (target === undefined && !continueOnUndefined) {
+				return pointerTarget;
+			}
 
 			if (clone || target === undefined) {
 				if (Array.isArray(target)) {
@@ -77,7 +84,10 @@ export class Pointer<T = any, U = any> {
 	}
 
 	get(object: T): U {
-		const pointerTarget: PointerTarget = walk(this.segments, object, false);
+		const pointerTarget: PointerTarget = walk(this.segments, object, false, false);
+		if (pointerTarget.target === undefined) {
+			return undefined as any;
+		}
 		return pointerTarget.target[pointerTarget.segment];
 	}
 

--- a/tests/unit/state/Patch.ts
+++ b/tests/unit/state/Patch.ts
@@ -65,7 +65,7 @@ describe('state/Patch', () => {
 			assert.deepEqual(result.object, { test: 'test' });
 			assert.deepEqual(result.undoOperations, [
 				{ op: OperationType.TEST, path: new Pointer('/test'), value: 'test' },
-				{ op: OperationType.REPLACE, path: new Pointer('/test'), value: undefined }
+				{ op: OperationType.REMOVE, path: new Pointer('/test') }
 			]);
 		});
 
@@ -77,7 +77,7 @@ describe('state/Patch', () => {
 			assert.deepEqual(result.object, { foo: { bar: { qux: 'test' } } });
 			assert.deepEqual(result.undoOperations, [
 				{ op: OperationType.TEST, path: new Pointer('/foo/bar/qux'), value: 'test' },
-				{ op: OperationType.REPLACE, path: new Pointer('/foo/bar/qux'), value: undefined }
+				{ op: OperationType.REMOVE, path: new Pointer('/foo/bar/qux') }
 			]);
 		});
 

--- a/tests/unit/state/Pointer.ts
+++ b/tests/unit/state/Pointer.ts
@@ -69,6 +69,7 @@ describe('state/Pointer', () => {
 		const pointer = new Pointer('/foo/bar/qux');
 		const obj = {};
 		assert.strictEqual(pointer.get(obj), undefined);
+		assert.deepEqual(obj, {});
 	});
 
 	it('walk deep path that does not exist with clone', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that undos for operations passed from a single command are in the correct order and create a `REMOVE` operation instead of a `REPLACE` when the previous state is undefined. 

Using `REPLACE` adds a key with an `undefined` value which is not a correct representation of the previous state.

Finally ensure that calling `get` doesn't create keys on the state object as it incorrectly creates a `REMOVE` undo operation with a value of `undefined`

Related to #175 
