### PR TITLE
Export the StoreContainer from StoreContainer module

### DIFF
--- a/src/StoreContainer.ts
+++ b/src/StoreContainer.ts
@@ -1,4 +1,4 @@
 import { StoreContainer } from './StoreInjector';
-export { StoreContainer } from './StoreInjector';
+export { StoreContainer, createStoreContainer } from './StoreInjector';
 
 export default StoreContainer;

--- a/src/StoreContainer.ts
+++ b/src/StoreContainer.ts
@@ -1,0 +1,4 @@
+import { StoreContainer } from './StoreInjector';
+export { StoreContainer } from './StoreInjector';
+
+export default StoreContainer;

--- a/tests/unit/StoreContainer.ts
+++ b/tests/unit/StoreContainer.ts
@@ -1,0 +1,163 @@
+const { beforeEach, describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { v, WNODE } from '@dojo/widget-core/d';
+import { Registry } from '@dojo/widget-core/Registry';
+
+import DefaultStoreContainer, { createStoreContainer, StoreContainer } from './../../src/StoreContainer';
+import { Store } from './../../src/Store';
+
+interface State {
+	foo: string;
+	bar: string;
+}
+
+const TypedStoreContainer = createStoreContainer<State>();
+
+describe('StoreContainer', () => {
+	let store: Store<State>;
+	let registry: Registry;
+
+	beforeEach(() => {
+		registry = new Registry();
+		store = new Store<State>();
+	});
+
+	describe('Default StoreContainer', () => {
+		it('Should render the WNode with the properties and children', () => {
+			class Foo extends WidgetBase {}
+			class FooContainer extends DefaultStoreContainer<State>(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				render() {
+					return super.render();
+				}
+			}
+			const fooContainer = new FooContainer();
+			fooContainer.__setProperties__({ key: '1' });
+			const child = v('div');
+			fooContainer.__setChildren__([child]);
+			const renderResult = fooContainer.render();
+			assert.deepEqual(renderResult, {
+				properties: { key: '1' },
+				children: [child],
+				type: WNODE,
+				widgetConstructor: Foo
+			});
+		});
+
+		it('Should always render a container', () => {
+			let invalidateCounter = 0;
+			class Foo extends WidgetBase {}
+			class FooContainer extends DefaultStoreContainer<State>(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				invalidate() {
+					invalidateCounter++;
+				}
+			}
+			const fooContainer = new FooContainer();
+			registry.defineInjector('state', () => () => store);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 1);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 2);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 3);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 4);
+		});
+	});
+
+	describe('StoreContainer', () => {
+		it('Should render the WNode with the properties and children', () => {
+			class Foo extends WidgetBase {}
+			class FooContainer extends StoreContainer<State>(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				render() {
+					return super.render();
+				}
+			}
+			const fooContainer = new FooContainer();
+			fooContainer.__setProperties__({ key: '1' });
+			const child = v('div');
+			fooContainer.__setChildren__([child]);
+			const renderResult = fooContainer.render();
+			assert.deepEqual(renderResult, {
+				properties: { key: '1' },
+				children: [child],
+				type: WNODE,
+				widgetConstructor: Foo
+			});
+		});
+
+		it('Should always render a container', () => {
+			let invalidateCounter = 0;
+			class Foo extends WidgetBase {}
+			class FooContainer extends StoreContainer<State>(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				invalidate() {
+					invalidateCounter++;
+				}
+			}
+			const fooContainer = new FooContainer();
+			registry.defineInjector('state', () => () => store);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 1);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 2);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 3);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 4);
+		});
+	});
+
+	describe('Typed StoreContainer', () => {
+		it('Should render the WNode with the properties and children', () => {
+			class Foo extends WidgetBase {}
+			class FooContainer extends TypedStoreContainer(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				render() {
+					return super.render();
+				}
+			}
+			const fooContainer = new FooContainer();
+			fooContainer.__setProperties__({ key: '1' });
+			const child = v('div');
+			fooContainer.__setChildren__([child]);
+			const renderResult = fooContainer.render();
+			assert.deepEqual(renderResult, {
+				properties: { key: '1' },
+				children: [child],
+				type: WNODE,
+				widgetConstructor: Foo
+			});
+		});
+
+		it('Should always render a container', () => {
+			let invalidateCounter = 0;
+			class Foo extends WidgetBase {}
+			class FooContainer extends TypedStoreContainer(Foo, 'state', {
+				getProperties: (inject: Store<State>) => {}
+			}) {
+				invalidate() {
+					invalidateCounter++;
+				}
+			}
+			const fooContainer = new FooContainer();
+			registry.defineInjector('state', () => () => store);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 1);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 2);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 3);
+			fooContainer.__setProperties__({});
+			assert.strictEqual(invalidateCounter, 4);
+		});
+	});
+});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -3,3 +3,4 @@ import './Store';
 import './process';
 import './state/all';
 import './StoreInjector';
+import './StoreContainer';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

It is currently confusing that the `StoreContainer` is exported from the `StoreInjector` module. This change adds a new module for `StoreContainer` and re-exports from `StoreInjector` (for backwards compatibility). In a future release this will be moved completely to `StoreContainer`.
