### PR TITLE
Add registerStoreInjector helper function

### DIFF
--- a/src/StoreInjector.ts
+++ b/src/StoreInjector.ts
@@ -6,6 +6,7 @@ import { beforeProperties } from '@dojo/widget-core/decorators/beforeProperties'
 import { alwaysRender } from '@dojo/widget-core/decorators/alwaysRender';
 import { InjectorItem, RegistryLabel, Constructor, DNode } from '@dojo/widget-core/interfaces';
 import { Store } from './Store';
+import { Registry } from '@dojo/widget-core/Registry';
 
 const registeredInjectorsMap: WeakMap<WidgetBase, InjectorItem<Store>[]> = new WeakMap();
 
@@ -99,4 +100,21 @@ export function createStoreContainer<S>() {
 	) => {
 		return StoreContainer(component, name, { paths, getProperties });
 	};
+}
+
+export interface StoreInjectorOptions {
+	key?: RegistryLabel;
+	registry?: Registry;
+}
+
+export function registerStoreInjector<T>(store: Store<T>, options: StoreInjectorOptions = {}) {
+	const { key = 'state', registry = new Registry() } = options;
+
+	if (registry.hasInjector(key)) {
+		throw new Error(`Store has already been defined for key ${key.toString()}`);
+	}
+	registry.defineInjector(key, () => {
+		return () => store;
+	});
+	return registry;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a helper function for registering the store as an injector in a registry.
