### PR TITLE
Ensure properties are typed when using the StoreContainer

### DIFF
--- a/src/StoreInjector.ts
+++ b/src/StoreInjector.ts
@@ -10,8 +10,8 @@ import { Registry } from '@dojo/widget-core/Registry';
 
 const registeredInjectorsMap: WeakMap<WidgetBase, InjectorItem<Store>[]> = new WeakMap();
 
-export interface GetProperties<S extends Store, T = any> {
-	(payload: S, properties: T): T;
+export interface GetProperties<S extends Store, W extends WidgetBase<any, any> = WidgetBase<any, any>> {
+	(payload: S, properties: W['properties']): W['properties'];
 }
 
 export type StoreContainerPath<
@@ -25,11 +25,13 @@ export type StoreContainerPath<
 
 export interface StoreInjectConfig<S = any> {
 	name: RegistryLabel;
-	getProperties: GetProperties<Store<S>>;
+	getProperties: GetProperties<Store<S>, any>;
 	paths?: StoreContainerPath<S>[];
 }
 
-export type StoreContainer<T extends WidgetBase> = Constructor<WidgetBase<Partial<T['properties']>, T['children'][0]>>;
+export type StoreContainer<T extends WidgetBase<any, any>> = Constructor<
+	WidgetBase<Partial<T['properties']>, T['children'][0]>
+>;
 
 /**
  * Decorator that registers a store injector with a container based on paths when provided
@@ -77,7 +79,7 @@ export function storeInject<S>(config: StoreInjectConfig<S>) {
 export function StoreContainer<S = any, W extends WidgetBase<any, any> = WidgetBase<any, any>>(
 	component: Constructor<W> | RegistryLabel,
 	name: RegistryLabel,
-	{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>> }
+	{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>, W> }
 ): StoreContainer<W> {
 	@alwaysRender()
 	@storeInject({ name, paths, getProperties })
@@ -96,7 +98,7 @@ export function createStoreContainer<S>() {
 	return <W extends WidgetBase<any, any>>(
 		component: Constructor<W> | RegistryLabel,
 		name: RegistryLabel,
-		{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>> }
+		{ paths, getProperties }: { paths?: StoreContainerPath<S>[]; getProperties: GetProperties<Store<S>, W> }
 	) => {
 		return StoreContainer(component, name, { paths, getProperties });
 	};

--- a/tests/unit/StoreContainer.ts
+++ b/tests/unit/StoreContainer.ts
@@ -25,9 +25,11 @@ describe('StoreContainer', () => {
 
 	describe('Default StoreContainer', () => {
 		it('Should render the WNode with the properties and children', () => {
-			class Foo extends WidgetBase {}
+			class Foo extends WidgetBase<{ foo: string }> {}
 			class FooContainer extends DefaultStoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, properties) => {
+					return properties;
+				}
 			}) {
 				render() {
 					return super.render();
@@ -50,7 +52,9 @@ describe('StoreContainer', () => {
 			let invalidateCounter = 0;
 			class Foo extends WidgetBase {}
 			class FooContainer extends DefaultStoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				invalidate() {
 					invalidateCounter++;
@@ -73,7 +77,9 @@ describe('StoreContainer', () => {
 		it('Should render the WNode with the properties and children', () => {
 			class Foo extends WidgetBase {}
 			class FooContainer extends StoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				render() {
 					return super.render();
@@ -96,7 +102,9 @@ describe('StoreContainer', () => {
 			let invalidateCounter = 0;
 			class Foo extends WidgetBase {}
 			class FooContainer extends StoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				invalidate() {
 					invalidateCounter++;
@@ -117,9 +125,12 @@ describe('StoreContainer', () => {
 
 	describe('Typed StoreContainer', () => {
 		it('Should render the WNode with the properties and children', () => {
-			class Foo extends WidgetBase {}
+			class Foo extends WidgetBase<{ foo: string }> {}
 			class FooContainer extends TypedStoreContainer(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, properties) => {
+					properties;
+					return properties;
+				}
 			}) {
 				render() {
 					return super.render();
@@ -142,7 +153,9 @@ describe('StoreContainer', () => {
 			let invalidateCounter = 0;
 			class Foo extends WidgetBase {}
 			class FooContainer extends TypedStoreContainer(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				invalidate() {
 					invalidateCounter++;

--- a/tests/unit/StoreInjector.ts
+++ b/tests/unit/StoreInjector.ts
@@ -201,7 +201,9 @@ describe('StoreInjector', () => {
 		it('Should render the WNode with the properties and children', () => {
 			class Foo extends WidgetBase {}
 			class FooContainer extends StoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				render() {
 					return super.render();
@@ -224,7 +226,9 @@ describe('StoreInjector', () => {
 			let invalidateCounter = 0;
 			class Foo extends WidgetBase {}
 			class FooContainer extends StoreContainer<State>(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				invalidate() {
 					invalidateCounter++;
@@ -247,7 +251,9 @@ describe('StoreInjector', () => {
 		it('Should render the WNode with the properties and children', () => {
 			class Foo extends WidgetBase {}
 			class FooContainer extends TypedStoreContainer(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				render() {
 					return super.render();
@@ -270,7 +276,9 @@ describe('StoreInjector', () => {
 			let invalidateCounter = 0;
 			class Foo extends WidgetBase {}
 			class FooContainer extends TypedStoreContainer(Foo, 'state', {
-				getProperties: (inject: Store<State>) => {}
+				getProperties: (inject, props) => {
+					return props;
+				}
 			}) {
 				invalidate() {
 					invalidateCounter++;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Type the `StoreContainer` properly so that the widgets properties are correctly inferred from the widget that container is wrapping.
